### PR TITLE
vmprofiler nix API

### DIFF
--- a/tools/vmprofiler/default.nix
+++ b/tools/vmprofiler/default.nix
@@ -1,0 +1,25 @@
+# vmprofiler nix library API:
+#
+#   vmprofiler.analyze_dir <directory>:
+#     Analyze a directory containing vmprofile data.
+#     Creates summary files (text and csv.)
+#
+#   NYI: vmprofiler.analyze_shm <shm-tarball>:
+#     Analyze a Snabb shm tarball.
+#     (This runs analyze_dir on $shm/engine/vmprofile.)
+{ pkgs ? import ../../nix/pkgs.nix {} }:
+
+with pkgs; with stdenv;
+
+let buildInputs = with rPackages; [ R dplyr bit64 tibble purrr readr stringr ];
+in
+
+{
+  analyze_dir = dir: runCommand "vmprofiler-summary" { inherit buildInputs; } ''
+    mkdir $out
+    Rscript - <<EOF
+      source("${./vmprofiler.R}")
+      summarize_vmprofile("${dir}", "$out")
+    EOF
+  '';
+}


### PR DESCRIPTION
Added a simple nix API to vmprofiler. You can run it like this:

    $ git clone https://github.com/studio/studio
    $ nix-build -E '(import studio/tools/vmprofiler {}).analyze_dir(/var/run/snabb/12345/engine/vmprofile)'

which will create output like this:

```
$ ls -1 result/
gc.csv
gc.txt
overview.csv
overview.txt
what.csv
what.txt
where.csv
where.txt
```

This is not the most convenient interface in the world, but it's a start!