### PR TITLE
Create 'studio' front-end with snabb process report

### DIFF
--- a/bin/studio
+++ b/bin/studio
@@ -1,0 +1,102 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p getopt
+
+set -e
+
+studio="$(dirname $(readlink -f $0))/.."
+
+usage() {
+    cat >&2 <<EOF
+Studio - software diagnostics environment
+
+Usage:
+
+  studio <subcommand> options
+
+Subcommands:
+
+    snabb gui                  Open the graphical user interface.
+    snabb process              Analyze a Snabb timeline log file.
+
+Timeline options:
+
+    -i, --input SHMDIR         Select the shm folder to operate on.
+
+EOF
+    exit 1
+}
+
+[ "$#" == 0 ] && usage
+
+error() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+subcommand="$1"; shift
+case "$subcommand" in
+    --help|-h)
+        usage
+        ;;
+    gui)
+        gui
+        ;;
+    import)
+        info=""
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                -i|--info)
+                    info="$2"
+                    shift 2
+                    ;;
+                *)
+                    nix-build $studio/nix/import-product.nix \
+                              --arg info $(readlink -f "$info") \
+                              --arg data $(readlink -f "$1") \
+                              --no-out-link
+                    shift 1
+                    ;;
+            esac
+        done
+        ;;
+    process)
+        tmpdir=$(mktemp -d)
+        nixexpr=$tmpdir/process-report.nix
+ 
+        cat > $nixexpr <<EOF
+with import $(pwd)/../nix/import.nix {};
+
+snabbProcessReport
+  (snabbProcessSet [
+EOF
+        group="other"
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                -g|--group)
+                    group=$2
+                    shift 2
+                    ;;
+                *)
+                    path=$1
+                    cat >> $nixexpr <<EOF
+    (snabbProcessGroup "$group" [
+      (snabbProcess (snabbProcessTarball $path)) ])
+EOF
+                    shift 1
+                    ;;
+            esac
+        done
+        cat >> $nixexpr <<EOF
+  ])
+EOF
+        echo "building:"
+        cat $nixexpr
+        nix-build $nixexpr
+        rm -rf "$tmpdir"
+        ;;
+    *)
+        echo "unrecognized subcommand: $subcommand"
+        echo "use -h/--help for usage"
+        ;;
+esac
+        

--- a/bin/studio
+++ b/bin/studio
@@ -16,7 +16,19 @@ Usage:
 Subcommands:
 
     snabb gui                  Open the graphical user interface.
-    snabb process              Analyze a Snabb timeline log file.
+    snabb processes            Analyze a set of Snabb processes.
+
+snabb processes arguments:
+
+    DIRECTORY                  Snabb process state directory to analyze.
+                               Many directories can be specified.
+    -g, --group GROUP          Group name for the following Snabb processes.
+                               Use to assign Snabb processes to groups.
+
+    -o, --output PATH          Create output (symlink to directory) at PATH.
+    -v, --verbose              Print verbose trace information.
+    -n, --nix ARGS             Extra arguments passed to nix-build.
+    -j, --jobs NUM             Execute NUM build jobs in parallel.
 
 Timeline options:
 
@@ -27,6 +39,8 @@ EOF
 }
 
 [ "$#" == 0 ] && usage
+[ "$1" == "snabb" ] || usage
+shift 1
 
 error() {
     echo "error: $*" >&2
@@ -41,43 +55,44 @@ case "$subcommand" in
     gui)
         gui
         ;;
-    import)
-        info=""
-        while [ "$#" -gt 0 ]; do
-            case "$1" in
-                -i|--info)
-                    info="$2"
-                    shift 2
-                    ;;
-                *)
-                    nix-build $studio/nix/import-product.nix \
-                              --arg info $(readlink -f "$info") \
-                              --arg data $(readlink -f "$1") \
-                              --no-out-link
-                    shift 1
-                    ;;
-            esac
-        done
-        ;;
-    process)
+    processes)
         tmpdir=$(mktemp -d)
         nixexpr=$tmpdir/process-report.nix
  
         cat > $nixexpr <<EOF
 with import $(pwd)/../nix/import.nix {};
-
 snabbProcessReport
   (snabbProcessSet [
 EOF
+        verbose="no"
         group="other"
+        output="./result"
         while [ "$#" -gt 0 ]; do
             case "$1" in
+                -n|--nix)
+                    nix=$2
+                    shift 2
+                    ;;
+                -j|--jobs)
+                    parallel="-j $2"
+                    shift 2
+                    ;;
+                -o|--output)
+                    output="$2"
+                    shift 2
+                    ;;
+                -v|--verbose)
+                    verbose="yes"
+                    shift 1
+                    ;;
                 -g|--group)
                     group=$2
                     shift 2
                     ;;
                 *)
-                    path=$1
+                    path=$(readlink -f $1)
+                    checkfile=$path/engine/latency.histogram
+                    [ -f "$checkfile" ] || error "cannot read $checkfile"
                     cat >> $nixexpr <<EOF
     (snabbProcessGroup "$group" [
       (snabbProcess (snabbProcessTarball $path)) ])
@@ -89,9 +104,14 @@ EOF
         cat >> $nixexpr <<EOF
   ])
 EOF
-        echo "building:"
-        cat $nixexpr
-        nix-build $nixexpr
+        if [ "$verbose" == "yes" ]; then
+            echo "nix expression:" >&2
+            cat $nixexpr | sed 's/^/  /g' >&2
+        fi
+        storepath=$(nix-build $nix $parallel -o $output $nixexpr)
+        if [ $? == 0 ]; then
+            echo "created $output -> $storepath"
+        fi
         rm -rf "$tmpdir"
         ;;
     *)

--- a/bin/studio
+++ b/bin/studio
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p getopt
+#! nix-shell -i bash -p nix
 
 set -e
 
@@ -60,7 +60,7 @@ case "$subcommand" in
         nixexpr=$tmpdir/process-report.nix
  
         cat > $nixexpr <<EOF
-with import $(pwd)/../nix/import.nix {};
+with import $studio/nix/import.nix {};
 snabbProcessReport
   (snabbProcessSet [
 EOF

--- a/nix/import.nix
+++ b/nix/import.nix
@@ -1,0 +1,59 @@
+{ pkgs ? (import ./pkgs.nix) {} }:
+
+with pkgs;
+let snabbr = import ../tools/snabbr {}; in
+
+{
+  snabbProcessTarball = dir:
+    runCommand "snabb-process-tarball" { inherit dir; }
+      ''
+        cp -pr $dir dir
+        (cd dir && tar cf ../state.tar *)
+        # xz -0 is fast & effective on snabb state
+        xz -0 -T0 state.tar
+        mv state.tar.xz $out
+      '';
+
+  # Snabb process state snapshot. Source is a compressed tarball.
+  snabbProcess = tarball:
+    let timelineSummary = snabbr.summary tarball; in
+    runCommand "studio-product-snabb-process"
+      { inherit tarball timelineSummary; }
+      ''
+        mkdir $out
+        echo 'type: snabbProcess' > $out/product-info.yaml
+        ln -s $tarball $out/state.tar.xz
+        mkdir $out/summary
+        # Create summary data from the timeline
+        ln -s $timelineSummary $out/summary/timeline
+        # Extract small relevant files
+        (cd $out/summary; tar -xf $tarball engine/latency.histogram engine/vmprofile)
+      '';
+
+  # Snabb process group. Source is a list of process state snapshots.
+  snabbProcessGroup = groupName: processes:
+    runCommand "studio-product-snabb-process-group" { inherit groupName processes; }
+      ''
+        mkdir -p $out/processes
+        echo "type: snabbProcessGroup" >  $out/product-info.yaml
+        echo "group: $groupName"     >> $out/product-info.yaml
+        for p in $processes; do
+          ln -s $p $out/processes/
+        done
+      '';
+
+  # Set of Snabb process groups.
+  snabbProcessSet = groups:
+    runCommand "studio-product-snabb-process-set" { inherit groups; }
+      ''
+        mkdir -p $out/groups
+        echo 'type: snabbProcessGroups' > $out/product-info.yaml
+        for g in $groups; do
+          ln -s $g $out/groups/
+        done
+      '';
+
+  snabbProcessReport = processSet:
+    snabbr.report processSet;
+}
+

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,1 @@
+import (fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/6a0155d2b7cb10aef1c63b654a2b172d78fd89b4.tar.gz)

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -1,0 +1,38 @@
+# timeliner nix library API:
+#
+#   timeliner.summary <shm-tarball>:
+#     Generate summary data from a timeline for further processing.
+#
+#   timeliner.visualize <summary>:
+#     Generate visualizations (PNG files) from timeline summary data.
+#
+# The output of timeliner.summary is the input to timeliner.visualize.
+# The processing is split into two parts so that the summary data can
+# be archived separately from the timeline files (e.g. to save space
+# by keeping only the summary data and discarding the full timeline.)
+
+{ pkgs ? import ../../nix/pkgs.nix {} }:
+
+with pkgs; with stdenv;
+
+let buildInputs = with rPackages; [ R dplyr readr ggplot2 bit64 mgcv ]; in
+
+{
+  # shmTarball: path to a tarball containing a Snabb shm folder.
+  summary = shmTarball: runCommand "timeline-summary" { inherit buildInputs; } ''
+      mkdir $out
+      tar xf ${shmTarball}
+      Rscript - <<EOF
+        source("${./timeliner.R}")
+        summarize_timeline("engine/timeline", "$out")
+      EOF
+    '';
+  # summaryData: Output from the summary derivation above.
+  visualize = summaryData: runCommand "timeline-visualization" { inherit buildInputs; } ''
+    mkdir $out
+    Rscript - <<EOF
+      source("${./timeliner.R}")
+      plot_timeline_summary("${summaryData}", "$out")
+    '';
+}
+

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -26,7 +26,7 @@ let buildInputs = with rPackages;
   summary = shmTarball: runCommand "timeline-summary" { inherit buildInputs; } ''
       mkdir $out
       tar xf ${shmTarball}
-      Rscript - <<EOF
+      (Rscript - &>log.txt || cat log.txt) <<EOF
         source("${./timeliner.R}")
         summarize_timeline("engine/timeline", "$out")
       EOF
@@ -34,7 +34,7 @@ let buildInputs = with rPackages;
   # summaryData: Output from the summary derivation above.
   visualize = summaryData: runCommand "timeline-visualization" { inherit buildInputs; } ''
     mkdir $out
-    Rscript - <<EOF
+    (Rscript - &>log.txt || cat log.txt) <<EOF
       source("${./timeliner.R}")
       plot_timeline_summary("${summaryData}", "$out")
     '';
@@ -44,9 +44,8 @@ let buildInputs = with rPackages;
         mkdir $out
         ln -s $processSet data
         cp ${./.}/*.R .
-        echo $processSet
-        ls -l
-        Rscript - <<EOF
+        (Rscript &>log.txt - || cat log.txt) <<EOF
+        options(warn = -1)
         library(rmarkdown); 
         source('${./vmprofiler.R}')
         source('${./latencyr.R}')

--- a/tools/snabbr/latencyr.R
+++ b/tools/snabbr/latencyr.R
@@ -1,0 +1,28 @@
+# latencyr.R: Process Snabb shared memory latency histogram objects
+
+# ------------------------------------------------------------
+# High-level API functions
+# ------------------------------------------------------------
+
+summarize_latency <- function(filename) {
+  read_latency_histogram(filename) %>%
+    mutate(csum = cumsum(bucket)) %>%
+    group_by(usec = floor(log10(bound*1e6))) %>%
+    summarize(percent = last(csum) / last(total))
+}
+
+read_latency_histogram <- function(filename) {
+  f <- file(filename, "rb")
+  minimum <- readBin(f, "double", n=1, size=8, endian="little")[[1]]
+  log_growth_factor <- readBin(f, "double", n=1, size=8, endian="little")[[1]]
+  bucketsU64 <- readBin(f, "double", n=510, size=8, endian="little")
+  class(bucketsU64) <- "integer64"
+  buckets <- as.numeric(bucketsU64)
+  close(f)
+  tibble(minimum = minimum,
+       log_growth_factor = log_growth_factor,
+       microseconds = c(0, minimum + (exp(log_growth_factor) ^ (1:507)), Inf),
+       total = buckets[[1]],
+       count = buckets[2:length(buckets)])
+}
+

--- a/tools/snabbr/processes.Rmd
+++ b/tools/snabbr/processes.Rmd
@@ -1,7 +1,10 @@
 ---
-title: "Snabb process analysis"
+title: "Snabb processes analysis"
 output:
-  html_notebook:
+  html_document:
+    toc: true
+    toc_float: true
+    toc_depth: 3
     fig_width: 8
     fig_height: 6
 ---

--- a/tools/snabbr/processes.Rmd
+++ b/tools/snabbr/processes.Rmd
@@ -1,0 +1,23 @@
+---
+title: "Snabb process analysis"
+output:
+  html_notebook:
+    fig_width: 8
+    fig_height: 6
+---
+
+```{r include=FALSE}
+source("vmprofiler.R")
+source("latencyr.R")
+source("snabbr.R")
+
+set <- read_process_set("data")
+```
+
+## Latency
+
+```{r echo=FALSE}
+#set$latency.histogram
+plot_latency_histogram(set$latency.histogram)
+```
+

--- a/tools/snabbr/processes.Rmd
+++ b/tools/snabbr/processes.Rmd
@@ -6,11 +6,8 @@ output:
     fig_height: 6
 ---
 
-```{r include=FALSE}
-source("vmprofiler.R")
-source("latencyr.R")
-source("snabbr.R")
-
+```{r include=FALSE,debug=TRUE}
+library(knitr)
 set <- read_process_set("data")
 ```
 

--- a/tools/snabbr/processes.Rmd
+++ b/tools/snabbr/processes.Rmd
@@ -16,8 +16,43 @@ set <- read_process_set("data")
 
 ## Latency
 
+Latency histogram data records the duration of each breath that the engine takes. Every breath is counted into one of ~500 bins corresponding to durations from one microsecond up to one second.
+
 ```{r echo=FALSE}
-#set$latency.histogram
 plot_latency_histogram(set$latency.histogram)
 ```
 
+## VMProfile
+
+VMProfile data records code profiler samples. One sample is taken each microsecond and each sample is counted in a bin keyed by both the class of the app that is currently running and the virtual machine state.
+
+```{r echo=FALSE}
+plot_vmprofile(set$vmprofile)
+```
+
+States:
+
+- `asm` when the JIT is assembling machine code.
+- `c` when running a Lua-C API call (typically into the LuaJIT runtime system.)
+- `exit` when a trace exit handler is running.
+- `foreign` when running machine code not assembled by the JIT (typically via FFI.)
+- `gc` when garbage collecting.
+- `interp` when interpreting Lua bytecodes.
+- `head` when running JIT machine code that is not part of a trace loop.
+- `loop` when running JIT machine code that is part of a trace loop.
+- `record` when the JIT is recording a bytecode trace.
+
+
+## Timeline
+
+### Breaths efficiency
+
+```{r echo=FALSE, message=FALSE}
+breath_efficiency(set$breaths)
+```
+
+### Callback efficiency
+
+```{r echo=FALSE, message=FALSE}
+callback_efficiency(set$callbacks)
+```

--- a/tools/snabbr/snabbr.R
+++ b/tools/snabbr/snabbr.R
@@ -1,0 +1,51 @@
+# snabbr.R: Analyze Snabb process state (timeline, latency histogram, etc)
+
+# ------------------------------------------------------------
+# Read data
+# ------------------------------------------------------------
+
+read_process_set <- function (dir) {
+  groupNames <- Sys.glob(file.path(dir, "groups", "*"))
+  groups <- flatten(map(groupNames, read_group))
+  # XXX obviously could be factored tighter...
+  list(latency.histogram = ldply(groups[names(groups) == "latency.histogram"]),
+       vmprofile = ldply(groups[names(groups) == "vmprofile"]),
+       callbacks = ldply(groups[names(groups) == "callbacks"]),
+       breaths = ldply(groups[names(groups) == "breaths"]))
+}
+
+read_group <- function (dir) {
+  product_info <- yaml.load_file(file.path(dir, 'product-info.yaml'))
+  group <- product_info$group
+  processes <- Sys.glob(file.path(dir, "processes", "*"))
+  data <- flatten(map(processes, read_process))
+  lapply(data, function(x) { x$group <- group; x })
+}
+
+read_process <- function (dir) {
+  process <- str_match(dir, "/([:alnum:]{3})[:alnum:]*-studio-product-snabb-process$")[2]
+  data <- list(latency.histogram = read_latency_histogram(file.path(dir, "summary", "engine", "latency.histogram")),
+               vmprofile = read_files(Sys.glob(file.path(dir, "summary", "engine", "vmprofile", "*"))),
+               callbacks = read_rds(file.path(dir, "summary", "timeline", "callbacks.rds.xz")),
+               breaths = read_rds(file.path(dir, "summary", "timeline", "breaths.rds.xz")))
+  lapply(data, function(x) { x$process <- process; x })
+}
+
+# ------------------------------------------------------------
+# Latency histogram
+# ------------------------------------------------------------
+
+summarize_latency_histogram <- function(data) {
+  data %>%
+    group_by(group, bucket = ceiling(log10(microseconds*1e6))) %>%
+    summarize(count = sum(count))
+}
+
+plot_latency_histogram <- function (data) {
+  ggplot(filter(data, count>0), aes(x=microseconds, y=count, color=group)) +
+    geom_point(shape=1, alpha=0.75) +
+    scale_y_log10(labels = scales::comma, breaks = 10 ^ (1:9)) +
+    scale_x_log10(limits = c(1, 1e6), breaks = 10 ^ (1:6), labels = scales::comma) +
+    annotation_logticks(sides="bl")
+}
+

--- a/tools/snabbr/snabbr.R
+++ b/tools/snabbr/snabbr.R
@@ -1,5 +1,9 @@
 # snabbr.R: Analyze Snabb process state (timeline, latency histogram, etc)
 
+library(plyr)
+library(yaml)
+library(ggplot2)
+
 # ------------------------------------------------------------
 # Read data
 # ------------------------------------------------------------

--- a/tools/snabbr/timeliner.R
+++ b/tools/snabbr/timeliner.R
@@ -223,13 +223,4 @@ breath_efficiency <- function(br, cutoff=5000) {
     expand_limits(x=0, y=0)
 }
 
-callback_efficiency <- function(cb) {
-  d <- cb %>%
-        mutate(packets = pmax(inpackets, outpackets)) %>%
-        filter(packets>0)
-  ggplot(d, aes(y = pmin(1000, cycles/packets), x = packets)) +
-    geom_point(color="blue", alpha=0.25, shape=1) +
-    geom_smooth(se=F, weight=1, alpha=0.1) +
-    facet_wrap(~ event)
-}
 

--- a/tools/snabbr/timeliner.R
+++ b/tools/snabbr/timeliner.R
@@ -219,7 +219,8 @@ breath_efficiency <- function(br, cutoff=5000) {
                           "(ommitting ", scales::percent(pct), " outliers above ", scales::comma(cutoff), " cycles/packet cutoff)",
                           sep=""),
          y = "cycles/packet",
-         x = "packets processed in engine breath (burst size)")
+         x = "packets processed in engine breath (burst size)") +
+    expand_limits(x=0, y=0)
 }
 
 callback_efficiency <- function(cb) {

--- a/tools/snabbr/timeliner.R
+++ b/tools/snabbr/timeliner.R
@@ -209,7 +209,7 @@ breath_duration <- function(br, cutoff=1000000) {
 
 breath_efficiency <- function(br, cutoff=5000) {
   nonzero <- filter(br, packets>0)
-  d <- nonzero %>% filter(cycles/packets <= 5000)
+  d <- nonzero %>% filter(cycles/packets <= cutoff)
   pct <- (nrow(nonzero) - nrow(d)) / nrow(nonzero)
   ggplot(d, aes(y = cycles / packets, x = packets)) +
     geom_point(color="blue", alpha=0.25, shape=1) +

--- a/tools/snabbr/timeliner.R
+++ b/tools/snabbr/timeliner.R
@@ -1,0 +1,234 @@
+# timerliner.R: Process Snabb timeline logs
+
+library(dplyr)
+library(stringr)
+library(bit64)
+library(readr)
+library(ggplot2)
+
+# ------------------------------------------------------------
+# High-level API functions
+# ------------------------------------------------------------
+
+# Load a binary timeline and save summary data for further processing.
+summarize_timeline <- function(filename, outdir) {
+  save_timeline_summaries(read_timeline(filename), outdir)
+}
+
+# Load summary data and save diverse visualizations.
+plot_timeline_summary <- function(summarydir, outdir) {
+  dir.create(outdir, recursive=T, showWarnings=F)
+  # Breaths
+  br <- read_rds(file.path(summarydir, "breaths.rds.xz"))
+  ggsave(file.path(outdir, "breath_duration.png"),   breath_duration(br))
+  ggsave(file.path(outdir, "breath_outliers.png"),   breath_outliers(br))
+  ggsave(file.path(outdir, "breath_efficiency.png"), breath_efficiency(br))
+  # Callbacks
+  cb <- read_rds(file.path(summarydir, "callbacks.rds.xz"))
+  ggsave(file.path(outdir, "callback_efficiency.png"), callback_efficiency(cb))
+}
+
+# ------------------------------------------------------------
+# Reading and decoding timelines
+# ------------------------------------------------------------
+
+# Read a timeline file into a data frame.
+read_timeline <- function(filename) {
+  tl <- read_binary_timeline(filename)
+  tl$numa <- as.factor(tl$numa)
+  tl$core <- as.factor(tl$core)
+  tl$unixtime <- calculate_unixtime(tl)
+  tl$cycles <- calculate_cycles(tl)
+  # Sort entries by unix time. Should roughly take care of log wrap-around.
+  # See FIXME comment in unixtime() though.
+#  tl <- arrange(tl, unixtime)
+  tl
+}
+
+# Read a timeline file into a tibble.
+read_binary_timeline <- function(filename) {
+  f <- file(filename, "rb")
+  # Read fields
+  magic <- readBin(f, raw(), n=8, endian="little")
+  version <- readBin(f, "integer", n=2, size=2, endian="little")
+  log_bytes <- readBin(f, "integer", n=1, size=4, endian="little")
+  strings_bytes <- readBin(f, "integer", n=1, size=4, endian="little")
+  # Check compat
+  if (!all(magic == c(0x01, 0x00, 0x1d, 0x44, 0x23, 0x72, 0xff, 0xa3))) {
+    stop("bad magic number")
+  }
+  if (version[1] != 2 & version[1] != 3) {
+    stop("unrecognized major version")
+  }
+  seek(f, 64)
+  entries <- readBin(f, "double", n=log_bytes/8, size=8, endian="little")
+  elem0 = seq(1, log_bytes/8, 64/8)
+  # Tricky: Second element is integer on disk but double in R
+  tmp <- entries[elem0+1]
+  class(tmp) <- "integer64"
+  entries[elem0+1] <- as.numeric(tmp)
+  tl <- tibble(tsc = entries[elem0],
+               msgid = bitwAnd(entries[elem0+1], 0xFFFF),
+               core = bitwAnd(bitwShiftR(entries[elem0+1], 16), 0xF),
+               numa = bitwShiftR(entries[elem0+1], 24),
+               arg0 = entries[elem0+2],
+               arg1 = entries[elem0+3],
+               arg2 = entries[elem0+4],
+               arg3 = entries[elem0+5],
+               arg4 = entries[elem0+6],
+               arg5 = entries[elem0+7])
+  tl <- na.omit(tl)
+  # Read strings
+  stringtable <- character(strings_bytes/16) # dense array
+  start <- 64+log_bytes
+  seek(f, start)
+  repeat {
+    id <- 1+(seek(f)-start)/16
+    s <- readBin(f, "character")
+    if (s == "") break;
+    stringtable[id] <- s
+    seek(f, ceiling(seek(f)/16) * 16) # seek to 16-byte alignment
+  }
+  # Decode string messages
+  messages <- tibble(msgid = 0:(length(stringtable)-1), message = stringtable) %>%
+    filter(message != "") %>%
+    mutate(summary = str_extract(message, "^[^\n]+"),
+           level = as.integer(str_extract(summary, "^[0-9]")),
+           event = gsub("^[0-9]\\|([^:]+):.*", "\\1", summary))
+  # Combine messages with events
+  left_join(tl, messages, by="msgid")
+}
+
+# Calculate unix timestamps for each entry.
+calculate_unixtime <- function(tl) {
+  times <- filter(tl, grepl("got_monotonic_time", event))
+
+  # FIXME: Make sure the delta is taken between two timestamps from
+  # the _same CPU core_. If we take the delta between two timestamps
+  # whose TSCs are not synchronized (e.g. different NUMA nodes) then
+  # we will misestimate the clock speed (maybe even negative...)
+  
+  if (length(times) < 2) {
+    stop("could not calculate unix time: need two timestamps to compare.")  
+  } else {
+
+    # Calculate GHz (cycles per nanosecond) from timestamp deltas.
+    GHz <- (max(times$tsc)-min(times$tsc)) / (max(times$arg0)-min(times$arg0))
+    # Pick an epoch (any will do)
+    reftsc <- last(times$tsc)
+    reftime <- last(times$arg0)
+    # Function from cycles to unix nanoseconds
+    unixtime <- function(tsc) {
+      reftime + ((tsc - reftsc) / GHz)
+    }
+    mapply(unixtime, tl$tsc)
+  }
+}
+
+# Calculate cycles since log entry of >= level ("lag") for each entry.
+calculate_cycles <- function(tl) {
+  # reference timestamp accumulator for update inside closure.
+  # index is log level and value is reference timestamp for delta.
+  ref <- as.numeric(rep(NA, 9))
+  tscdelta <- function(level, time) {
+    if (is.na(level)) { stop("level na") }
+    if (is.na(time)) { stop("time na") }
+    delta <- time - ref[level]
+    ref[1:level] <<- time
+    delta
+  }
+  mapply(tscdelta, tl$level, tl$tsc)
+}
+
+# ------------------------------------------------------------
+# Saving CSV summaries of timelines
+# ------------------------------------------------------------
+
+# Save R object summaries of a timeline.
+save_timeline_summaries <- function(tl, outdir=".") {
+  if (!dir.exists(outdir)) { dir.create(outdir, recursive=T) }
+  br <- breaths(tl)
+  cb <- callbacks(tl)
+  save_data(br, file.path(outdir, "breaths.rds.xz"))
+  save_data(cb, file.path(outdir, "callbacks.rds.xz"))
+}
+
+save_data <- function(data, filename) {
+  message("Saving ", filename)
+  write_rds(data, filename, compress="xz")
+}
+
+# Create a data frame with one row for each breath.
+breaths <- function(tl) {
+  tl %>% 
+    filter(grepl("breath_end|breath_start", event)) %>%
+    mutate(breath = arg0,
+           total_packets = arg1, total_bytes = arg2, total_ethbits = arg3,
+           packets = arg1-lag(arg1), bytes = arg2-lag(arg2), ethbits = arg3-lag(arg3)) %>%
+    filter(grepl("breath_end", event)) %>%
+    na.omit() %>%
+    select(tsc, unixtime, cycles, numa, core,
+           breath, total_packets, total_bytes, total_ethbits, packets, bytes, ethbits)
+}
+
+# Create a data frame with one row for each app callback.
+callbacks <- function(tl) {
+  tl %>% filter(grepl("^app.(pull|push)", event)) %>%
+    mutate(inpackets = arg0 - lag(arg0), inbytes = arg1 - lag(arg1),
+           outpackets = arg2 - lag(arg2), outbytes = arg3 - lag(arg3)) %>%
+    mutate(packets = pmax(inpackets, outpackets), bytes = pmax(inbytes + outbytes)) %>%
+    filter(grepl("^app.(pushed|pulled)", event)) %>%
+    na.omit() %>%
+    select(tsc, unixtime, cycles, numa, core,
+           event, packets, bytes, inpackets, inbytes, outpackets, outbytes)
+}
+
+# ------------------------------------------------------------
+# Visualizing the callbacks summary
+# ------------------------------------------------------------
+
+breath_outliers <- function(br, cutoff=1000000) {
+  d <- filter(br, cycles>cutoff)
+  ggplot(d, aes(y = cycles, x = packets)) +
+    scale_y_continuous(labels = scales::comma) +
+    geom_point(alpha=0.5, color="blue") +
+    labs(title = "Outlier breaths",
+           subtitle = paste("Breaths that took more than ", scales::comma(cutoff), " cycles ",
+                            "(", scales::percent(nrow(d)/nrow(br)), " of sampled breaths)", sep=""),
+           x = "packets processed in engine breath (burst size)")
+}
+
+breath_duration <- function(br, cutoff=1000000) {
+  d <- filter(br, cycles <= cutoff)
+  ggplot(d, aes(y = cycles, x = packets)) +
+    geom_point(color="blue", alpha=0.25, shape=1) +
+    geom_smooth(se=F, weight=1, alpha=0.1) +
+    labs(title = "Breath duration",
+         subtitle = "")
+}
+
+breath_efficiency <- function(br, cutoff=5000) {
+  nonzero <- filter(br, packets>0)
+  d <- nonzero %>% filter(cycles/packets <= 5000)
+  pct <- (nrow(nonzero) - nrow(d)) / nrow(nonzero)
+  ggplot(d, aes(y = cycles / packets, x = packets)) +
+    geom_point(color="blue", alpha=0.25, shape=1) +
+    geom_smooth(se=F, weight=1, alpha=0.1) +
+    labs(title = "Engine breath efficiency",
+         subtitle = paste("Processing cost in cycles per packet ",
+                          "(ommitting ", scales::percent(pct), " outliers above ", scales::comma(cutoff), " cycles/packet cutoff)",
+                          sep=""),
+         y = "cycles/packet",
+         x = "packets processed in engine breath (burst size)")
+}
+
+callback_efficiency <- function(cb) {
+  d <- cb %>%
+        mutate(packets = pmax(inpackets, outpackets)) %>%
+        filter(packets>0)
+  ggplot(d, aes(y = pmin(1000, cycles/packets), x = packets)) +
+    geom_point(color="blue", alpha=0.25, shape=1) +
+    geom_smooth(se=F, weight=1, alpha=0.1) +
+    facet_wrap(~ event)
+}
+

--- a/tools/snabbr/vmprofiler.R
+++ b/tools/snabbr/vmprofiler.R
@@ -1,0 +1,99 @@
+# vmprofiler.R: Process LuaJIT/Snabb VMProfile logs
+
+options(warn=-1)
+
+library(dplyr)
+library(bit64)
+library(tibble)
+library(tools)
+library(purrr)
+library(readr)
+library(stringr)
+
+# ------------------------------------------------------------
+# High-level API functions
+# ------------------------------------------------------------
+
+summarize_vmprofile <- function(inputdir, outputdir) {
+  dir.create(outputdir, recursive=T, showWarnings=F)
+  data <- read_files(Sys.glob(file.path(inputdir, "*")))
+  save_data(outputdir, "overview", analyze_profile(data))
+  save_data(outputdir, "what",     analyze_what(data))
+  save_data(outputdir, "gc",       analyze_gc(data))
+  save_data(outputdir, "where",    analyze_where(data))
+}
+
+# ------------------------------------------------------------
+# Reading and decoding profiler samples
+# ------------------------------------------------------------
+
+states <- c("interp", "c", "gc", "exit", "record", "opt", "asm")
+traces <- unlist(map(0:4096,
+                     function(t) { paste(c("head","loop","foreign", "gc"),t,sep=".") }))
+columns = c(states, traces)
+
+read_files <- function(filenames) {
+  return(do.call(rbind,lapply(filenames, read_file)))
+}
+
+read_file <- function(filename) {
+  f <- file(filename, 'rb')
+  profile <- tools::file_path_sans_ext(basename(filename))
+  # XXX check magic and version
+  seek(f, 8)
+  tmp <- readBin(f, "double", n=length(states)+4097*4, size=8, endian="little")
+  class(tmp) <- "integer64"    # cast to true type: int64
+  samples <- as.numeric(tmp)   # convert to numeric for R
+  close(f)
+  tibble(profile = profile, where = columns, num = samples) %>% filter(num>0)
+}
+
+# ------------------------------------------------------------
+# Analysis to create summaries (data frames)
+# ------------------------------------------------------------
+
+analyze_profile <- function(data) {
+  data %>%
+    group_by(profile) %>%
+    summarize(num = sum(num)) %>%
+    ungroup() %>%
+    transmute(profile = profile, percent = round(100*num/sum(num),1)) %>%
+    arrange(-percent) %>%
+    as.data.frame()
+}
+
+analyze_what <- function(data) {
+  data %>%
+    transform(what = str_match(where, "^[^.]*")) %>%
+    group_by(what) %>%
+    summarize(num = sum(num)) %>%
+    ungroup() %>%
+    transmute(what = what, percent = round(100*num/sum(num),1)) %>%
+    arrange(-percent) %>%
+    as.data.frame()
+}
+
+analyze_gc <- function(data) {
+  data %>% filter(grepl("gc", where)) %>% analyze_where()
+}
+
+analyze_where <- function(data) {
+  data %>%
+    transform(percent = round(100*num/sum(num),1)) %>%
+    arrange(profile, -percent) %>%
+    select(profile, where, percent) %>%
+    filter(percent >= 0.5) %>%
+    as.data.frame()
+}
+
+# ------------------------------------------------------------
+# Utilities
+# ------------------------------------------------------------
+
+# Save a data frame to a directory in both .csv and .txt format.
+save_data <- function(dir, name, data) {
+  write_csv(data, file.path(dir, paste(name, '.csv', sep="")))
+  capture.output(print(data, row.names=F), type="output",
+                 file = file.path(dir, paste(name, '.txt', sep="")))
+}
+

--- a/tools/vmprofiler/vmprofiler.R
+++ b/tools/vmprofiler/vmprofiler.R
@@ -1,7 +1,5 @@
 # vmprofiler.R: Process LuaJIT/Snabb VMProfile logs
 
-options(warn=-1)
-
 library(dplyr)
 library(bit64)
 library(tibble)
@@ -42,6 +40,7 @@ read_file <- function(filename) {
   # XXX check magic and version
   seek(f, 8)
   tmp <- readBin(f, "double", n=length(states)+4097*4, size=8, endian="little")
+  close(f)
   class(tmp) <- "integer64"    # cast to true type: int64
   samples <- as.numeric(tmp)   # convert to numeric for R
   tibble(profile = profile, where = columns, num = samples) %>% filter(num>0)


### PR DESCRIPTION
This branch introduces the shell command `studio` that serves as a multi-purpose front-end to the project. Currently there is one command supported:

```
studio process [-g groupname] <shmfolder> ...
```

This command creates a report on a set of Snabb processes that can optionally be categorized into named groups (for group-wise comparison.) Essentially it looks into the "shm" (shared memory objects) folders of the processes and analyzes the relevant data: latency histogram, timelines, vmprofiles. So it can report a lot of details about performance and make comparisons between processes and groups.

Just now this is rough and only the latency data is shown. However, it's a big milestone for me because it is the first time that I have been able to run a shell one-liner that does a whole bunch of processing with R, etc, to create an output.

The processing is very nix-centric. Each shm folder is imported into the nix store in a canonical compressed format (tar.xz). Nix is managing all of the processing: it can parallelize the processing and cache the intermediate results. This is really handy because preprocessing the timeline logs take a long time (my slow R code) and it's great to run that in parallel and also reuse it automatically when tweaking the report. 

The design is based loosely on [styx](https://github.com/styx-static/styx). There is a wrinkle that the `process` command first uses shell code to generate a nix expression, referencing all of the inputs on the file system, and then passes that to `nix-build` to do all the other work of processing data and generating reports.