### PR TITLE
snabbr: Revised latency histogram graph

### DIFF
--- a/tools/snabbr/processes.Rmd
+++ b/tools/snabbr/processes.Rmd
@@ -43,7 +43,7 @@ breath_size(set$breaths)
 
 Latency histogram data records the duration of each breath that the engine takes. Every breath is counted into one of ~500 bins corresponding to durations from one microsecond up to one second.
 
-```{r echo=FALSE}
+```{r echo=FALSE, warning=FALSE}
 plot_latency_histogram(set$latency.histogram)
 ```
 


### PR DESCRIPTION
The new breath duration (processing latency) graph is supposed to look like this:

![breath-duration](https://cloud.githubusercontent.com/assets/13791/26054531/355a32a4-396d-11e7-8670-9032370328a3.png)

However there seems to be a compatibility bug somehow because I wrote the code with a different version of R than the one that Studio uses. I need to migrate my development environment over to the Studio nix env (currently using a random version of RStudio on MacOSX.)