### PR TITLE
Add command: studio snabb rstudio

### DIFF
--- a/bin/studio
+++ b/bin/studio
@@ -17,6 +17,7 @@ Subcommands:
 
     snabb gui                  Open the graphical user interface.
     snabb processes            Analyze a set of Snabb processes.
+    snabb rstudio              Start RStudio IDE with Snabb modules.
 
 snabb processes arguments:
 
@@ -54,6 +55,9 @@ case "$subcommand" in
         ;;
     gui)
         gui
+        ;;
+    rstudio)
+        nix-shell -j 10 $studio/tools/snabbr -A rstudio --run rstudio
         ;;
     processes)
         tmpdir=$(mktemp -d)

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/6a0155d2b7cb10aef1c63b654a2b172d78fd89b4.tar.gz)
+import (fetchTarball https://github.com/NixOS/nixpkgs/archive/760248360c1d3b2a0a648a76803180e7a6c13275.tar.gz)

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -56,5 +56,18 @@ let buildInputs = with rPackages;
         EOF
       '';
 
+  rstudio =
+    let Rprofile = writeText "Rprofile" ''
+      source('${./vmprofiler.R}')
+      source('${./latencyr.R}')
+      source('${./timeliner.R}')
+      source('${./snabbr.R}')
+      message("Loaded snabbr libraries.")
+    ''; in
+    runCommand "rstudio" { R_PROFILE_USER = Rprofile;
+                           buildInputs = buildInputs ++ [ rstudio ]; } ''
+      echo "This derivation only collects dependencies together."
+      echo "Please use with nix-shell and run 'rstudio' manually."
+    '';
 }
 

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -26,7 +26,7 @@ let buildInputs = with rPackages;
   summary = shmTarball: runCommand "timeline-summary" { inherit buildInputs; } ''
       mkdir $out
       tar xf ${shmTarball}
-      (Rscript - &>log.txt || cat log.txt) <<EOF
+      (Rscript - &>log.txt || (cat log.txt ; false)) <<EOF
         source("${./timeliner.R}")
         summarize_timeline("engine/timeline", "$out")
       EOF
@@ -34,7 +34,7 @@ let buildInputs = with rPackages;
   # summaryData: Output from the summary derivation above.
   visualize = summaryData: runCommand "timeline-visualization" { inherit buildInputs; } ''
     mkdir $out
-    (Rscript - &>log.txt || cat log.txt) <<EOF
+    (Rscript - &>log.txt || (cat log.txt ; false)) <<EOF
       source("${./timeliner.R}")
       plot_timeline_summary("${summaryData}", "$out")
     '';


### PR DESCRIPTION
New command:

    studio snabb rstudio

Runs the RStudio IDE (https://www.rstudio.com) with the snabbr libraries loaded and the same versions of all R packages that the rest of Studio uses.

This is to make it easy to hack R code and know that it will run the same under nix. R has a big ecosystem with lots of libraries being updated etc so compatibility problems are common if you use different versions for development and deployment.

also updated Studio to use the latest version of nixpkgs.