### PR TITLE
New command: studio snabb vmprofile <dir>

### DIFF
--- a/bin/studio
+++ b/bin/studio
@@ -15,9 +15,9 @@ Usage:
 
 Subcommands:
 
-    snabb gui                  Open the graphical user interface.
     snabb processes            Analyze a set of Snabb processes.
     snabb rstudio              Start RStudio IDE with Snabb modules.
+    snabb vmprofile            Analyze "VMProfile" sampling profiler data.
 
 snabb processes arguments:
 
@@ -31,9 +31,9 @@ snabb processes arguments:
     -n, --nix ARGS             Extra arguments passed to nix-build.
     -j, --jobs NUM             Execute NUM build jobs in parallel.
 
-Timeline options:
+snabb vmprofile arguments:
 
-    -i, --input SHMDIR         Select the shm folder to operate on.
+    DIRECTORY                  Snabb process state directory to analyze.
 
 EOF
     exit 1
@@ -58,6 +58,25 @@ case "$subcommand" in
         ;;
     rstudio)
         nix-shell -j 10 $studio/tools/snabbr -A rstudio --run rstudio
+        ;;
+    vmprofile)
+        tmpdir=$(mktemp -d)
+        nixexpr=$tmpdir/vmprofile-analysis.nix
+        [ "$#" == 1 ] || usage
+        [ -d "$1/engine/vmprofile" ] || error "can't open directory $1/engine/vmprofile"
+        path=$(readlink -f "$1")
+        output="./result"
+        cat > $nixexpr <<EOF
+with import $studio/nix/import.nix {};
+snabbVMProfileAnalysis $path
+EOF
+        storepath=$(nix-build $nixexpr)
+        status=$?
+        if [ $status == 0 ]; then
+            echo "created $output -> $storepath"
+        fi
+        rm -rf $tmpdir
+        exit $status
         ;;
     processes)
         tmpdir=$(mktemp -d)
@@ -113,10 +132,12 @@ EOF
             cat $nixexpr | sed 's/^/  /g' >&2
         fi
         storepath=$(nix-build $nix $parallel -o $output $nixexpr)
-        if [ $? == 0 ]; then
+        status=$?
+        if [ $status == 0 ]; then
             echo "created $output -> $storepath"
         fi
         rm -rf "$tmpdir"
+        exit $status
         ;;
     *)
         echo "unrecognized subcommand: $subcommand"

--- a/nix/import.nix
+++ b/nix/import.nix
@@ -55,5 +55,8 @@ let snabbr = import ../tools/snabbr {}; in
 
   snabbProcessReport = processSet:
     snabbr.report processSet;
+
+  snabbVMProfileAnalysis = process:
+    snabbr.vmprofile process;
 }
 

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -44,7 +44,7 @@ let buildInputs = with rPackages;
         mkdir $out
         ln -s $processSet data
         cp ${./.}/*.R .
-        (Rscript &>log.txt - || cat log.txt) <<EOF
+        (Rscript &>log.txt - || (cat log.txt ; false)) <<EOF
         options(warn = -1)
         library(rmarkdown); 
         source('${./vmprofiler.R}')

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -58,6 +58,7 @@ let buildInputs = with rPackages;
 
   rstudio =
     let Rprofile = writeText "Rprofile" ''
+      library(stats) # https://stackoverflow.com/questions/26935095/r-dplyr-filter-not-masking-base-filter
       source('${./vmprofiler.R}')
       source('${./latencyr.R}')
       source('${./timeliner.R}')

--- a/tools/snabbr/default.nix
+++ b/tools/snabbr/default.nix
@@ -70,5 +70,14 @@ let buildInputs = with rPackages;
       echo "This derivation only collects dependencies together."
       echo "Please use with nix-shell and run 'rstudio' manually."
     '';
+
+  vmprofile = process:
+    runCommand "snabb-process-vmprofile" { inherit process buildInputs; } ''
+      mkdir $out
+      (Rscript &>log.txt - || (cat log.txt ; false)) <<EOF
+      source('${./vmprofiler.R}')
+      vmprofile.summarize("$process/engine/vmprofile", "$out")
+      EOF
+    '';
 }
 

--- a/tools/snabbr/snabbr.R
+++ b/tools/snabbr/snabbr.R
@@ -1,6 +1,5 @@
 # snabbr.R: Analyze Snabb process state (timeline, latency histogram, etc)
 
-library(plyr)
 library(dplyr)
 library(tidyr)
 library(yaml)
@@ -31,7 +30,7 @@ read_group <- function (dir) {
 read_process <- function (dir) {
   process <- str_match(dir, "/([:alnum:]{3})[:alnum:]*-studio-product-snabb-process$")[2]
   data <- list(latency.histogram = read_latency_histogram(file.path(dir, "summary", "engine", "latency.histogram")),
-               vmprofile = read_files(Sys.glob(file.path(dir, "summary", "engine", "vmprofile", "*"))),
+               vmprofile = vmprofile.read_files(Sys.glob(file.path(dir, "summary", "engine", "vmprofile", "*"))),
                callbacks = read_rds(file.path(dir, "summary", "timeline", "callbacks.rds.xz")),
                breaths = read_rds(file.path(dir, "summary", "timeline", "breaths.rds.xz")))
   lapply(data, function(x) { x$process <- process; x })

--- a/tools/snabbr/snabbr.R
+++ b/tools/snabbr/snabbr.R
@@ -1,5 +1,6 @@
 # snabbr.R: Analyze Snabb process state (timeline, latency histogram, etc)
 
+library(plyr)
 library(dplyr)
 library(tidyr)
 library(yaml)
@@ -61,10 +62,10 @@ plot_latency_histogram <- function (data) {
 plot_vmprofile <- function (data) {
   d <- data %>%
     group_by(group, process, profile, what = str_match(where, "^[^.]*")) %>%
-    dplyr::summarize(num = sum(num)) %>%
+    dplyr::summarize(samples = sum(samples)) %>%
     ungroup() %>%
     group_by(process, profile) %>%
-    dplyr::mutate(percent = 100*num/sum(num))
+    dplyr::mutate(percent = 100*samples/sum(samples))
   ggplot(d, aes(x = what, y = percent, color = group)) +
     geom_boxplot() +
     theme(axis.text.x = element_text(angle = 45, hjust = 0.9)) +


### PR DESCRIPTION
Add the command `studio snabb vmprofile <dir>` to analyze VMProfile data for one Snabb process. Creates `./result` directory containing a small set of numeric reports in both .txt and .csv formats.

Example output:

```
[luke@interlaken:~/git/studio]$ bin/studio snabb vmprofile ~/git/snabb/src/shm/6841                                                                                                                                 
created ./result -> /nix/store/vx5yb53d6vf1jscl6ih0qd0bw28zxbaf-snabb-process-vmprofile

[luke@interlaken:~/git/studio]$ ls result
gc.csv  gc.txt  overview.csv  overview.txt  what.csv  what.txt  where.csv  where.txt

[luke@interlaken:~/git/studio]$ cat result/overview.txt 
     profile percent
 apps.socket      74
      engine      20
      Source       3
        Sink       2
         Tee       2

[luke@interlaken:~/git/studio]$ cat result/where.txt 
     profile       where percent samples
        Sink     loop.35     1.5     583
      Source     loop.29     2.2     871
      Source  foreign.29     0.5     207
         Tee     loop.33     1.1     417
 apps.socket           c    22.5    8820
 apps.socket      interp    22.1    8675
 apps.socket          gc    20.1    7886
 apps.socket  foreign.53     2.7    1045
 apps.socket foreign.109     1.9     759
 apps.socket    head.108     0.8     310
 apps.socket     head.53     0.7     274
 apps.socket  foreign.46     0.6     231
 apps.socket    head.109     0.5     191
      engine  foreign.48     3.3    1293
      engine  foreign.58     3.1    1213
      engine  foreign.84     2.9    1133
      engine     head.40     2.4     946
      engine      interp     1.3     509
      engine  foreign.40     1.0     382
      engine     head.48     0.5     188
      engine     head.53     0.5     215
```
