### PR TITLE
backend: Add inspector (preview)

### DIFF
--- a/backend/bin/inspect
+++ b/backend/bin/inspect
@@ -30,8 +30,7 @@ output=$(readlink -f "$output")
 if [ -e "$what" ]; then
     what=$(readlink -f "$what") # canonicalize file/directory
 elif (echo "$what" | grep -q "^[a-z]*://"); then
-    what=$(nix-build -E "fetchTarball \"$what\"" || \
-           nix-build -E "builtin.fetchurl \"$what\"")
+    what=$(nix-prefetch-url --print-path --unpack "$what" | tail -1)
 fi
 
 echo "input: $what" >&2

--- a/backend/bin/inspect
+++ b/backend/bin/inspect
@@ -1,0 +1,63 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p bash nix parallel
+
+set -e
+
+here=$(dirname $(readlink -f $0))
+studio=$(readlink -f $here/../..)
+
+usage() {
+    cat >&2 <<EOF
+Usage: $(basename $0) [-o DIR] <what>
+
+The inspector uses the Studio backend to "do what I mean" with a file,
+directory, or URL. It applies every available analysis, expecting most
+of them to fail due to wrong input type, and keeps any that succeed.
+EOF
+}
+
+if [ $# == 3 -a $1 == "-o" ]; then
+    output="$2"
+    what="$3"
+elif [ $# == 1 ]; then
+    output="."
+    what="$1"
+else
+    usage
+fi
+    
+output=$(readlink -f "$output")
+if [ -e "$what" ]; then
+    what=$(readlink -f "$what") # canonicalize file/directory
+elif (echo "$what" | grep -q "^[a-z]*://"); then
+    what=$(nix-build -E "fetchTarball \"$what\"" || \
+           nix-build -E "builtin.fetchurl \"$what\"")
+fi
+
+echo "input: $what" >&2
+
+# First run nix build and persevere through failures.
+echo "running builds.." >&2
+nix-build -Q -j 10 --keep-going \
+          $studio/backend/inspector --arg what "$what" \
+          2>&1 | grep building 1>&2
+
+echo "collecting results.." >&2
+
+# Now pick up the builds that succeeded.
+modules=0
+outputs=0
+derivations=$(nix-instantiate --quiet $studio/backend/inspector --arg what "$what" 2>/dev/null)
+for drv in $derivations; do
+    modules=$[$modules + 1]
+    output=$(nix-store -q --outputs "$drv" | head -1)
+    if nix-store --query --deriver $output &>/dev/null; then
+        shortname=$(basename $output | sed -e 's/^[^-]*-//')
+        nix-store --add-root "$shortname" --indirect -r "$drv" >/dev/null
+        outputs=$[$outputs + 1]
+        echo $shortname
+    fi
+done
+
+echo "($outputs/$modules inspector modules succeeded)" >&2
+

--- a/backend/inspector/default.nix
+++ b/backend/inspector/default.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../../../nix/pkgs.nix {}
+, what } @args:
+with pkgs;
+
+{
+  hexdump = import modules/hexdump.nix args;
+  pdl     = import modules/pcap2xml.nix args;
+  vmprofile = import modules/vmprofile.nix args;
+}

--- a/backend/inspector/modules/hexdump.nix
+++ b/backend/inspector/modules/hexdump.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../../../nix/pkgs.nix {}
+, what }:
+with pkgs;
+
+runCommand "hexdump" { inherit what; nativeBuildInputs = [ utillinux ]; } ''
+  mkdir $out
+  hexdump -C $what > $out/hexdump.txt
+  echo text/hexdump > $out/.studio-type
+''

--- a/backend/inspector/modules/pcap2xml.nix
+++ b/backend/inspector/modules/pcap2xml.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../../../nix/pkgs.nix {}
+, what }:
+with pkgs;
+
+runCommand "pcap2xml" { inherit what; nativeBuildInputs = [ wireshark-cli ]; } ''
+  mkdir $out
+  tshark -Tpdml -r $what > $out/pdl.xml
+  echo text/xml/pdml > $out/.studio-type
+''

--- a/backend/inspector/modules/vmprofile.nix
+++ b/backend/inspector/modules/vmprofile.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import ../../../nix/pkgs.nix {}
+, what }:
+with pkgs;
+
+let vmprofiler = import ../../../tools/vmprofiler { inherit pkgs; }; in
+
+vmprofiler.analyze_dir what


### PR DESCRIPTION
The inspector is a DWIM (do what I mean) interface to the Studio backend.

Studio is able to translate many input formats (e.g. a Snabb process snapshot) into many output formats (e.g. a visualization from R.) The tricky part for an end-user is how to operate it: you probably don't want to have to write a nix expression by hand every time you are inspecting a file.

The solution here is to give the file to the inspector. It will automatically try to process the file in a large number of different ways, most of which will fail because the file won't be the right type, and then it will give you all of the results that built successfully.

So then it is easy to operate the backend. You just pass it a file/directory/url and then browse whatever it happens to spit out.

Currently the processing modules in the inspector are just examples and not really a true interface to the Studio backend code of the present and future.