### PR TITLE
nixpkgs: Add nixpkgs overlay with studio + pharo

### DIFF
--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,0 +1,6 @@
+let overlays = import ./overlays.nix;
+    # base on nixpkgs release-17.03 from 15-07-2016.
+    nixpkgs = import (fetchTarball https://github.com/NixOS/nixpkgs/archive/8e75b4dc7b1553026c70d95a34c408dabb852943.tar.gz);
+in
+nixpkgs { overlays = overlays; }
+

--- a/nixpkgs/overlays.nix
+++ b/nixpkgs/overlays.nix
@@ -1,0 +1,8 @@
+[
+  (self: super: {
+    pharo = super.callPackage ./pharo/vm {};
+  })
+  (self: super: {
+    studio-vnc = super.callPackage ./studio/frontend {};
+  })
+]

--- a/nixpkgs/pharo/vm/default.nix
+++ b/nixpkgs/pharo/vm/default.nix
@@ -1,0 +1,105 @@
+{ stdenv, fetchurl, fetchFromGitHub, bash, unzip, glibc, openssl, gcc, mesa, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, runCommand, ... }:
+
+# Build the Pharo VM
+stdenv.mkDerivation rec {
+  name = "pharo";
+  version = "git.${revision}";
+  src = fetchFromGitHub {
+    owner = "pharo-project";
+    repo = "pharo-vm";
+    rev = revision;
+    sha256 = "0dkiy5fq1xn2n93cwf767xz24c01ic0wfw94jk9nvn7pmcfj7m62";
+  };
+  # This metadata will be compiled into the VM and introspectable
+  # from Smalltalk. This has been manually extracted from 'git log'.
+  #
+  # The build would usually generate this automatically using
+  # opensmalltalk-vm/.git_filters/RevDateURL.smudge but that script
+  # is too impure to run from nix.
+  revision = "6a63f68a3dd4deb7c17dd2c7ac6e4dd4b0b6d937";
+  source-date = "Tue May 30 19:41:27 2017 -0700";
+  source-url  = "https://github.com/pharo-project/pharo-vm";
+
+  # Shared data (for the sources file)
+  pharo-share = import ./share.nix { inherit stdenv fetchurl unzip runCommand; };
+
+  # Note: -fPIC causes the VM to segfault.
+  hardeningDisable = [ "format" "pic"
+                       # while the VM depends on <= gcc48:
+                       "stackprotector" ];
+
+  # Regenerate the configure script.
+  # Unnecessary? But the build breaks without this.
+  autoreconfPhase = ''
+    pushd platforms/unix/config
+    make
+    popd
+  '';
+
+  # Configure with options modeled on the 'mvm' build script from the vm.
+  configureScript = "platforms/unix/config/configure";
+  configureFlags = [ "--without-npsqueak"
+                     "--with-vmversion=5.0"
+                     "--with-src=spur64src" ];
+  CFLAGS = "-DPharoVM -DIMMUTABILITY=1 -msse2 -D_GNU_SOURCE -DCOGMTVM=0 -g -O2 -DNDEBUG -DDEBUGVM=0";
+  LDFLAGS = "-Wl,-z,now";
+
+  # VM sources require some patching before build.
+  prePatch = ''
+    patchShebangs build.linux64x64
+    # Fix hard-coded path to /bin/rm in a script
+    sed -i -e 's:/bin/rm:rm:' platforms/unix/config/mkmf
+    # Fill in mandatory metadata about the VM source version
+    sed -i -e 's!\$Date\$!$Date: ${source-date} $!' \
+           -e 's!\$Rev\$!$Rev: ${version} $!' \
+           -e 's!\$URL\$!$URL: ${source-url} $!' \
+           platforms/Cross/vm/sqSCCSVersion.h
+  '';
+
+  # Note: --with-vmcfg configure option is broken so copy plugin specs to ./
+  preConfigure = ''
+    cp build.linux64x64/pharo.cog.spur/plugins.{ext,int} .
+  '';
+
+  # (No special build phase.)
+
+  installPhase = ''
+    # Install in working directory and then copy
+    make install-squeak install-plugins prefix=$(pwd)/products
+
+    # Copy binaries & rename from 'squeak' to 'pharo'
+    mkdir -p "$out"
+    cp products/lib/squeak/5.0-*/squeak "$out/pharo"
+    cp -r products/lib/squeak/5.0-*/*.so "$out"
+    ln -s "${pharo-share}/lib/"*.sources "$out"
+
+    # Create a shell script to run the VM in the proper environment.
+    #
+    # These wrapper puts all relevant libraries into the
+    # LD_LIBRARY_PATH. This is important because various C code in the VM
+    # and Smalltalk code in the image will search for them there.
+    mkdir -p "$out/bin"
+
+    # Note: include ELF rpath in LD_LIBRARY_PATH for finding libc.
+    libs=$out:$(patchelf --print-rpath "$out/pharo"):${cairo}/lib:${mesa}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
+
+    # Create the script
+    cat > "$out/bin/pharo" <<EOF
+    #!/bin/sh
+    set -f
+    LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/pharo "\$@"
+    EOF
+    chmod +x "$out/bin/pharo"
+  '';
+
+  enableParallelBuilding = true;
+
+  # gcc 4.8 used for the build:
+  #
+  # gcc5 crashes during compilation; gcc >= 4.9 produces a
+  # binary that crashes when forking a child process. See:
+  # http://forum.world.st/OSProcess-fork-issue-with-Debian-built-VM-td4947326.html
+  #
+  # (stack protection is disabled above for gcc 4.8 compatibility.)
+  nativeBuildInputs = [ bash unzip glibc openssl gcc48 mesa freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid autoreconfHook ];
+}

--- a/nixpkgs/pharo/vm/share.nix
+++ b/nixpkgs/pharo/vm/share.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchurl, unzip, runCommand }:
+
+runCommand "pharo-share-1.0"
+  rec {
+    sources60Zip = fetchurl {
+      url = http://files.pharo.org/sources/PharoV60.sources.zip;
+      sha256 = "0xbdi679ryb2zg412xy6zkh22l20pmbl92m3qhfgzjvgybna8z2a";
+    };
+
+    buildInputs = [ unzip ];
+  }
+  ''
+    mkdir -p $out/lib
+    unzip $sources60Zip -d $out/lib/
+  ''

--- a/nixpkgs/studio/frontend/default.nix
+++ b/nixpkgs/studio/frontend/default.nix
@@ -1,0 +1,86 @@
+{ pkgs }:
+with pkgs; with stdenv;
+
+let
+  # Function to fetch a Pharo image from a zip file.
+  fetchImageZip = { name, version, url, sha256 }:
+    mkDerivation {
+      inherit name version;
+      sourceRoot = ".";
+      src = fetchurl {
+        inherit url sha256;
+      };
+      nativeBuildInputs = [ unzip ];
+      installPhase = ''
+        mkdir $out
+        cp *.image $out/pharo.image
+        cp *.changes $out/pharo.changes
+      '';
+    };
+
+  # Pharo image that includes all external dependencies.
+  # Built on Inria CI (Jenkins) with Metacello to install Studio.
+  baseImage = fetchImageZip rec {
+    name = "studio-${version}";
+    version = "10";
+    url = https://ci.inria.fr/pharo-contribution/job/Studio/default/15/artifact/Studio.zip;
+    sha256 = "0mpc1rs073dyr3j9q3r1mgyl0vwnn1wmzh57fkxdpf3s5d3300fv";
+  };
+
+  # Studio image that includes the exact code in this source tree.
+  # Built by refreshing the base image.
+  studioImage = runCommand "studio-image"
+    { nativeBuildInputs = [ pharo ];
+      frontendSrc = ../../../frontend; }
+    ''
+      cp ${baseImage}/* .
+      chmod +w pharo.image
+      chmod +w pharo.changes
+      substituteAll ${./loadStudio.st} ./loadStudio.st
+      pharo --nodisplay pharo.image st --quit ./loadStudio.st
+      mkdir $out
+      cp new.image $out/pharo.image
+      cp new.changes $out/pharo.changes
+    '';
+
+  # Script to start the Studio image with the Pharo VM.
+  studioScript = writeScript "studio-ui" ''
+    #!${stdenv.shell}
+    cp ${studioImage}/pharo.image pharo.image
+    cp ${studioImage}/pharo.changes pharo.changes
+    chmod +w pharo.image
+    chmod +w pharo.changes
+    ${pharo}/bin/pharo pharo.image
+  '';
+
+  # Configuration file to make ratpoison run Studio.
+  ratpoisonConfig = writeScript "studio-ratpoison-config" ''
+    escape F1
+    exec ${studioScript}
+  '';
+
+  # Script to run ratpoison with the config for Studio.
+  ratpoisonScript = writeScript "studio-ratpoison" ''
+    #!${stdenv.shell}
+    exec ${ratpoison}/bin/ratpoison -f ${ratpoisonConfig}
+  '';
+
+  # Script to run everything in VNC.
+  vncScript = writeScriptBin "studio-vnc" ''
+    #!${stdenv.shell}
+    if [ $# == 0 ]; then
+      display=1
+    elif [ $# == 1 ]; then
+      display=$1
+    fi
+    exec ${tigervnc}/bin/vncserver :$display \
+      -name "Studio (:$display)" \
+      -fg \
+      -autokill \
+      -xstartup ${ratpoisonScript} \
+      -SecurityTypes None
+  '';
+in
+  
+vncScript
+

--- a/nixpkgs/studio/frontend/loadStudio.st
+++ b/nixpkgs/studio/frontend/loadStudio.st
@@ -1,0 +1,27 @@
+"Studio loader.
+
+ (Why not use Metacello? Doesn't seem to work well in a sandbox
+ without network access.)"
+
+| repo window |
+
+repo := MCFileTreeRepository new directory: '@frontendSrc@' asFileReference.
+repo allFileNames do: [ :file |
+    Transcript show: 'Loading: ', file; cr.
+    (repo versionFromFileNamed: file) load.
+  ].
+
+World closeAllWindowsDiscardingChanges.
+
+window := GTInspector openOn: #WelcomeToStudio.
+window
+"
+  removeBoxes;
+  beSticky;
+  beUnresizeable;
+  beWithoutGrips;
+"
+  bounds: window world clearArea.
+
+Smalltalk saveAs: 'new'.
+


### PR DESCRIPTION
Overlays are functions that transform the Nix packages collection.
Here I am using overlays to add/customize packages instead of forking
nixpkgs. I hope overlays will be an easy way to keep in sync with
upstream nixpkgs.

The 'studio' package is new and covers creating the Pharo VM for
Studio and running that under VNC (with help from ratpoison wm.)