### PR TITLE
Installation made simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ studio; the mechanic workshop; a doctor surgery. It is a workspace
 that you can fill with the tools that help you do your work, where
 they will all be within easy reach when you want them.
 
-Studio is not a traditional software IDE. You don't write your source
-code in Studio. What you do is collect specialist tools for the kind
-of software you are working on. This could include profilers like
-Intel VTune, protocol analyzers like Wireshark, testers like Valgrind,
-and so on.
+Unlike a traditional IDE, you don't write your source code in Studio.
+Instead you collect a suite of specialist tools that help you develop
+your own specific application. This could include profilers like Intel
+VTune, protocol analyzers like Wireshark, testers like Valgrind, and
+so on. You can either build these tools yourself or import existing
+ones, depending on the situation.
 
 Studio is very new. The first applications being supported are
 [RaptorJIT](https://github.com/raptorjit/raptorjit) and
@@ -35,70 +36,59 @@ interested in experimenting with RaptorJIT code.
 
 ## Installation
 
-Studio is a GUI application that runs on Linux/x86-64. The recommended
-deployment method is to run Studio on a server and access it using
-VNC. You can also run it locally on your development machine. (If want
-to run locally on a Mac then you can create a Linux VM using Docker or
-VirtualBox.)
+Studio is a GUI application that runs on Linux/x86-64. You can run
+Studio locally (X11 mode) or remotely (VNC mode.) The default
+installation supports both options "out of the box."
+
+macOS users are advised to use VNC mode with Studio running on a
+server, a cloud VM, a Docker container, a VirtualBox VM, etc.
 
 #### Prerequisite: Nix
 
-Studio is installed using the Nix package manager. So you need to
-install Nix before installing Studio.
+Studio is installed using the Nix package manager. You need
+to [install Nix](https://nixos.org/nix/) before installing Studio.
+
+Here is a one-liner for installing Nix:
 
 ```
 $ curl https://nixos.org/nix/install | sh
 ```
 
-#### Installing for X11 GUI
+#### Installing Studio
 
-The command `studio-gui` runs the Studio GUI directly via X11. You
-need to have an X11 display server available. This is probably the
-right choice if you are installing on a machine that has a graphical
-desktop environment e.g. a Linux laptop or graphical VirtualBox VM.
-
-Installation:
+You can install Studio directly from a source tarball. Here is the
+command to install the current master branch:
 
 ```
-$ nix-env -i studio-gui -f https://github.com/studio/studio/archive/master.tar.gz
+$ nix-env -iA studio -f https://github.com/studio/studio/archive/master.tar.gz
 ```
 
-Running:
+You can rerun this command at any time to install the latest release.
+If you want to install a different version, from a particular tag or
+branch of repository, then you only need to update the URL.
+
+## Running
+
+You can run the Studio GUI either locally (X11) or remotely (VNC.) The
+command `studio-x11` runs the GUI directly on your X server while the
+command `studio-vnc` creates a VNC desktop running Studio for remote
+access.
 
 ```
-$ studio-gui
+$ studio-x11
+$ studio-vnc [extra-vncserver-args...]
 ```
 
-#### Installing for VNC GUI
+The VNC server used is `tigervnc`.
 
-The command `studio-gui-vnc` runs the Studio GUI behind a VNC remote
-desktop server. You can connect to the GUI from another host using
-your VNC client of choice. This is probably the right choice if you
-are installing Studio on a server (bare metal or cloud VM) that you
-will access remotely.
+### VNC and SSH remote access tips
 
-Installation:
-
-```
-$ nix-env -i studio-gui-vnc -f https://github.com/studio/studio/archive/master.tar.gz
-```
-
-Running:
-
-```
-$ studio-gui-vnc [extra-vncserver-args...]
-```
-
-where `[extra-vncserver-args...]` are additional arguments to the
-`tigervnc` vncserver.
-
-##### VNC Remote Access Tips
-
-- The recommended VNC client is `tigervnc`. This particularly supports resizing the desktop to suit the client window size. On MacOS with Homebrew you can install tigervnc with `brew cask install tigervnc-viewer`.
+- The recommended VNC client is `tigervnc` which supports automatically resizing the desktop to suit the client window size. On macOS with Homebrew you can install tigervnc with `brew cask install tigervnc-viewer` and then run `vncviewer <server>[:display]`.
 - Using SSH:
-    - Start a long-lived Studio session: `ssh <server> studio-gui-vnc`.
+    - Start a long-lived Studio session: `ssh <server> studio-vnc [:display]`. If no display is specified then an available one is assigned automatically.
     - Setup SSH port forwarding to (e.g.) display 7: `ssh -L 5907:localhost:5907 <server>`.
     - Connect with VNC client to (e.g.) display 7 over SSH forwarded port: `vncviewer localhost:7`.
+    - Shut down a Studio sessions: `ssh <server> vncserver -kill <:display>`.
 - See how the VNC setup is put together in [`backend/frontend/default.nix`](backend/frontend/default.nix).
 
 ### Using Studio

--- a/backend/frontend/default.nix
+++ b/backend/frontend/default.nix
@@ -1,6 +1,8 @@
 { pkgs }:
 with pkgs; with stdenv;
 
+let studio-version = import ../../nix/studio-version.nix; in
+
 let
   # Function to fetch a Pharo image from a zip file.
   fetchImageZip = { name, version, url, sha256 }:
@@ -20,8 +22,8 @@ let
 
   # Pharo image that includes all external dependencies.
   # Built on Inria CI (Jenkins) with Metacello to install Studio.
-  baseImage = fetchImageZip rec {
-    name = "studio-${version}";
+  base-image = fetchImageZip rec {
+    name = "studio-base-image-${version}";
     version = "19";
     url = "https://ci.inria.fr/pharo-contribution/job/Studio/default/${version}/artifact/Studio.zip";
     sha256 = "19jhw0fnca4450a7iv51mzq91wixm5gllq7qwnw9r4yxhnkm3vak";
@@ -49,10 +51,10 @@ let
 
   # Studio image that includes the exact code in this source tree.
   # Built by refreshing the base image.
-  studioImage = runCommand "studio-image"
+  studio-image = runCommand "studio-image"
     { nativeBuildInputs = [ pharo ]; }
     ''
-      cp ${baseImage}/* .
+      cp ${base-image}/* .
       chmod +w pharo.image
       chmod +w pharo.changes
       pharo --nodisplay pharo.image st --quit ${loadSmalltalkScript}
@@ -62,49 +64,62 @@ let
     '';
 
   # Script to start the Studio image with the Pharo VM.
-  studioScript = writeScript "studio-gui" ''
-    #!${stdenv.shell}
-    cp ${studioImage}/pharo.image pharo.image
-    cp ${studioImage}/pharo.changes pharo.changes
-    chmod +w pharo.image
-    chmod +w pharo.changes
-    export STUDIO_PATH=''${STUDIO_PATH:-${../..}}
-    ${pharo}/bin/pharo pharo.image
-  '';
+  studio-x11 = writeScriptBin "studio-x11-${studio-version}"
+    ''
+      #!${stdenv.shell}
+      cp ${studio-image}/pharo.image pharo.image
+      cp ${studio-image}/pharo.changes pharo.changes
+      chmod +w pharo.image
+      chmod +w pharo.changes
+      export STUDIO_PATH=''${STUDIO_PATH:-${../..}}
+      ${pharo}/bin/pharo pharo.image
+    '';
 
   # Configuration file to make ratpoison run Studio.
-  ratpoisonConfig = writeScript "studio-ratpoison-config" ''
-    escape F1
-    exec ${studioScript}
-  '';
+  ratpoisonConfig = writeScript "studio-ratpoison-config"
+    ''
+      escape F1
+      exec ${studio-x11}/bin/studio-x11
+    '';
 
   # Script to run ratpoison with the config for Studio.
-  ratpoisonScript = writeScript "studio-ratpoison" ''
-    #!${stdenv.shell}
-    exec ${ratpoison}/bin/ratpoison -f ${ratpoisonConfig}
-  '';
+  ratpoisonScript = writeScript "studio-ratpoison"
+    ''
+      #!${stdenv.shell}
+      exec ${ratpoison}/bin/ratpoison -f ${ratpoisonConfig}
+    '';
 
   # Script to run everything in VNC.
-  vncScript = writeScriptBin "studio-gui-vnc" ''
+  studio-vnc = writeScriptBin "studio-vnc-${studio-version}" ''
     #!${stdenv.shell}
-    if [ $# == 0 ]; then
-      display=1
-    elif [ $# == 1 ]; then
-      display=$1
-    fi
-    exec ${tigervnc}/bin/vncserver :$display \
-      -name "Studio (:$display)" \
-      -fg \
+    exec ${tigervnc}/bin/vncserver \
+      "$@" \
+      -name "Studio" \
       -autokill \
       -xstartup ${ratpoisonScript} \
       -SecurityTypes None
   '';
+
+  studio = runCommand "studio-${studio-version}"
+    {
+      meta = {
+        description = "A productive environment for working on your programs";
+      };
+    }
+    ''
+      mkdir -p $out/bin
+      ln -s ${studio-x11}/bin/studio-x11 $out/bin
+      ln -s ${studio-vnc}/bin/studio-vnc $out/bin
+    '';
 in
   
 {
-  studio-gui = studioScript;
-  studio-gui-vnc = vncScript;
-  studio-base-image = baseImage;
-  studio-image = studioImage;
+  # main package collection for 'nix-env -i'
+  inherit studio;
+  # individual packages
+  studio-gui = studio-x11;           # deprecated
+  studio-gui-vnc = studio-vnc;       # deprecated
+  studio-base-image = base-image;
+  studio-image = studio-image;
 }
 

--- a/backend/inspector/default.nix
+++ b/backend/inspector/default.nix
@@ -3,6 +3,7 @@
 with pkgs;
 
 {
+  raptorjit-auditlog = modules/raptorjit-auditlog.nix args;
   hexdump = import modules/hexdump.nix args;
   pdl     = import modules/pcap2xml.nix args;
   vmprofile = import modules/vmprofile.nix args;

--- a/overlays.nix
+++ b/overlays.nix
@@ -5,7 +5,7 @@
   (self: super:
     with super.callPackage ./backend/frontend {};
     {
-      inherit studio-gui studio-gui-vnc studio-base-image studio-image;
+      inherit studio studio-gui studio-gui-vnc studio-base-image studio-image;
       raptorjit = super.callPackage ./backend/raptorjit {};
       snabbr = super.callPackage ./backend/snabbr {};
       timeliner = super.callPackage ./backend/timeliner {};


### PR DESCRIPTION
Now you install with 'nix-env -iA studio' and that automatically
installs the x11 version, the vnc version, and tigervnc for easy
access to 'vncserver -kill ...'.

So installation is always done in the same way and you choose between
X11 vs VNC when you start Studio.