### PR TITLE
bin/studio: fix nix-shell invocation

### DIFF
--- a/bin/studio
+++ b/bin/studio
@@ -32,16 +32,23 @@ fi
 
 nixopts="-j 10 --option signed-binary-caches https://cache.nixos.org --option extra-binary-caches https://hydra.snabb.co"
 
+runstudio() {
+  attr="$1"
+  cmd="$2"
+  nix-shell $nixopts --run "$cmd" -E - <<EOF
+    with import $studio;
+    runCommandNoCC "studio" {
+      nativeBuildInputs = [ $attr ];
+    } ""
+EOF
+}
+
 case "$1" in
     vnc)
-        nix-shell $nixopts \
-            -E "(import $studio).studio-gui-vnc" \
-            --run studio-vnc
+        runstudio studio-gui-vnc studio-vnc
         ;;
     x11)
-        nix-shell $nixopts \
-            -E "(import "$studio").studio-gui" \
-            --run studio-x11
+        runstudio studio-gui studio-x11
         ;;
     *)
         error "Usage: studio <vnc|x11>"


### PR DESCRIPTION
Current 'studio' script doesn't work,
attributes need to be inputs to the expression
not the expression itself.

The implementation here is similar to how
nix-shell implements "-p attribute":

https://github.com/NixOS/nix/blob/d4dcffd64349bb52ad5f1b184bee5cc7c2be73b4/src/nix-build/nix-build.cc#L250

See also "makeShell" in newer nixpkgs:
https://github.com/NixOS/nixpkgs/blob/adc5c9b83df203c9e425efe00f9a788ed3554c2d/pkgs/build-support/mkshell/default.nix