### PR TITLE
studio-x11: Pass command line arguments to Pharo

### DIFF
--- a/backend/frontend/default.nix
+++ b/backend/frontend/default.nix
@@ -118,7 +118,7 @@ let
       chmod +w pharo.image
       chmod +w pharo.changes
       export STUDIO_PATH=''${STUDIO_PATH:-${../..}}
-      ${pharo}/bin/pharo pharo.image
+      ${pharo}/bin/pharo pharo.image "$@"
     '';
   };
 


### PR DESCRIPTION
If the user runs 'studio-x11 ...' then the ... arguments are passed on to the Pharo virtual machine.
