### PR TITLE
bin/studio: Use "nix-shell --pure" and explicitly provide nix

### DIFF
--- a/bin/studio
+++ b/bin/studio
@@ -30,7 +30,7 @@ fi
 # Run studio
 #
 
-nixopts="-j 10 --option signed-binary-caches https://cache.nixos.org --option extra-binary-caches https://hydra.snabb.co"
+nixopts="--pure -j 10 --option signed-binary-caches https://cache.nixos.org --option extra-binary-caches https://hydra.snabb.co"
 
 runstudio() {
   attr="$1"
@@ -38,7 +38,7 @@ runstudio() {
   nix-shell $nixopts --run "$cmd" -E - <<EOF
     with import $studio;
     runCommandNoCC "studio" {
-      nativeBuildInputs = [ $attr ];
+      nativeBuildInputs = [ nixUnstable $attr ];
     } ""
 EOF
 }


### PR DESCRIPTION
The benefit of --pure should be more obviously seeing dependency errors i.e. it somewhat prevents random software on the host from being visible to Studio.

The benefit of explicitly providing Nix via nix-shell is that we will control the version of Nix that Studio uses.