### PR TITLE
bin/studio: Skip hydra.snabb.co for now

### DIFF
--- a/bin/studio
+++ b/bin/studio
@@ -30,7 +30,7 @@ fi
 # Run studio
 #
 
-nixopts="--pure -j 10 --option signed-binary-caches https://cache.nixos.org --option extra-binary-caches https://hydra.snabb.co"
+nixopts="--pure -j 10"
 
 runstudio() {
   attr="$1"


### PR DESCRIPTION
Fix regression cause by over-eager enabling of an additional binary cache.