### PR TITLE
Frontend: Show RaptorJIT register/stack/sink assignments

### DIFF
--- a/frontend/Studio-RaptorJIT/Integer.extension.st
+++ b/frontend/Studio-RaptorJIT/Integer.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Integer }
+
+{ #category : #'*studio-raptorjit' }
+Integer >> asX64RegisterAssignment [
+	^ #(
+		rax rcx rdx rbx rsp rbp rsi rdi r8 r9 r10 r11 r12 r13 r14 r15
+		xmm0 xmm1 xmm2 xmm3 xmm4 xmm5 xmm6 xmm7 xmm8
+		xmm9 xmm10 xmm11 xmm12 xmm13 xmm14 mm15
+		) at: self + 1.
+
+]

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -194,12 +194,23 @@ RJITIRInstruction >> irRefString [
 ]
 
 { #category : #printing }
+RJITIRInstruction >> irRegisterString [
+	self isSunk ifTrue: [ ^ '{sink' ].
+	stackSlot > 0 ifTrue: [ ^ '[{1}]' format: { stackSlot radix: 16 } ].
+	register = 255 ifTrue: [ ^ '' ]. "None"
+	^ register asX64RegisterAssignment.
+
+]
+
+{ #category : #printing }
 RJITIRInstruction >> irString [
 	"LOOP is a special case"
 	opcode = #loop ifTrue: [ ^ self irRefString , ' ------ LOOP ------------' ].
 	^ String streamContents: [ :s |
 		s
 			nextPutAll: self irRefString;
+			space;
+			nextPutAll: (self irRegisterString padRightTo: 6);
 			space;
 			nextPutAll: (self isGuardedAssertion ifTrue: '>' ifFalse: ' ');
 			nextPutAll: (isPhiOperand ifTrue: '+' ifFalse: ' ');
@@ -285,6 +296,14 @@ RJITIRInstruction >> isStore [
 	^ #(astore hstore ustore fstore xstore) includes: opcode.
 ]
 
+{ #category : #testing }
+RJITIRInstruction >> isSunk [
+	"Logic copied from LuaJIT dump.lua"
+	^ (#(253 254) includes: register) and: 
+		[ #(0 255) includes: stackSlot ].
+
+]
+
 { #category : #initialization }
 RJITIRInstruction >> isTypeConversion [
 	^ opcode matchesRegex: 'conv|tobit|tostr|strto'.
@@ -355,7 +374,9 @@ RJITIRInstruction >> resolveIR: num in: aGCtrace [
 
 { #category : #initialization }
 RJITIRInstruction >> roassalColor [	
-	self isAllocation ifTrue: [ ^Color red. ].
+	self isAllocation ifTrue: [
+		^ self isSunk ifTrue: [ Color pink ] ifFalse: [ Color red ].
+	].
 	self isArithmetic ifTrue: [ ^Color paleGreen. ].
 	self isBitOp ifTrue: [ ^Color paleGreen darker. ].
 	"Calls"

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -197,8 +197,8 @@ RJITIRInstruction >> irRefString [
 RJITIRInstruction >> irRegisterString [
 	self isSunk ifTrue: [ ^ '{sink' ].
 	stackSlot > 0 ifTrue: [ ^ '[{1}]' format: { stackSlot radix: 16 } ].
-	register = 255 ifTrue: [ ^ '' ]. "None"
-	^ register asX64RegisterAssignment.
+	register < 128 ifTrue: [ ^ register asX64RegisterAssignment ].
+	^ ''. "None"
 
 ]
 


### PR DESCRIPTION
Allocations are now shown as pink (sunk) or red (unsunk.)

Register names and stack slots are now shown in IR listings.