### PR TITLE
Frontend: "Export to clipboard" buttons for Bytecode and IR listings

### DIFF
--- a/frontend/Studio-RaptorJIT/BlockClosure.extension.st
+++ b/frontend/Studio-RaptorJIT/BlockClosure.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #BlockClosure }
+
+{ #category : #'*studio-raptorjit' }
+BlockClosure >> gtInspectorActionCopyValueToClipboard [
+	^ GLMGenericAction new 
+		action: [ 
+			Clipboard clipboardText: self value.
+			UIManager default inform: 'Copied to clipboard'. ];
+		icon: GLMUIThemeExtraIcons glamorousSave;
+		title: 'Export to clipboard'.
+
+]

--- a/frontend/Studio-RaptorJIT/RJITBytecode.class.st
+++ b/frontend/Studio-RaptorJIT/RJITBytecode.class.st
@@ -16,6 +16,18 @@ Class {
 	#category : #'Studio-RaptorJIT'
 }
 
+{ #category : #printing }
+RJITBytecode >> bytecodeListingLine [
+	^ String streamContents: [ :s |
+		s
+			nextPutAll: (self framedepth printString padLeftTo: 3);
+			space;
+			nextPutAll: (self opcodeName padRightTo: 8);
+			space;
+			nextPutAll: (self sourceLine)].
+
+]
+
 { #category : #accessing }
 RJITBytecode >> framedepth [
 	^ framedepth

--- a/frontend/Studio-RaptorJIT/RJITBytecodeRecordLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITBytecodeRecordLog.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'Studio-RaptorJIT'
 }
 
+{ #category : #converting }
+RJITBytecodeRecordLog >> bytecodeListing [
+	^ String streamContents: [ :s |
+		bytecodes select: [ :bc | bc framedepth isNotNil ] thenDo: [ :bc |
+			s nextPutAll: bc bytecodeListingLine; cr. ] ].
+
+]
+
 { #category : #accessing }
 RJITBytecodeRecordLog >> bytecodes [
 	^ bytecodes select: [ :bc | bc opcode isNotNil ].
@@ -24,6 +32,7 @@ RJITBytecodeRecordLog >> gtInspectorBytecodesIn: composite [
 	composite fastTable
 		title: 'Bytecodes';
 		display: [ self bytecodes ];
+		addAction: [ self bytecodeListing ] gtInspectorActionCopyValueToClipboard;
 		enableElementIndex;
 		column: 'Index' evaluated: [ :x :idx | idx ] width: 60;
 		column: 'Depth' evaluated: #framedepth width: 60;

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -69,14 +69,13 @@ RJITTrace >> gtInspectorGCTraceIn: composite [
 
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorIRListingIn: composite [
-	| insns |
+	| listing |
 	<gtInspectorPresentationOrder: 3>
-	insns := self irInstructions.
+	listing := self irListing.
 	composite text
 		title: 'IR Listing';
-		display: (String streamContents: [ :s |
-			insns do: [ :i | s nextPutAll: i irString; cr. ] ]).
-
+		display: listing;
+		addAction: [ listing ] gtInspectorActionCopyValueToClipboard.
 ]
 
 { #category : #'gt-inspector-extension' }
@@ -120,6 +119,13 @@ RJITTrace >> irInstructions [
 		irInstructions do: [ :ins | ins link: self. ].
  		].
 	^ irInstructions.
+
+]
+
+{ #category : #'as yet unclassified' }
+RJITTrace >> irListing [
+	^ String streamContents: [ :s |
+		self irInstructions do: [ :i | s nextPutAll: i irString; cr. ] ].
 
 ]
 


### PR DESCRIPTION
Text dump to the clipboard for pasting into a local application e.g. Emacs.