### PR TITLE
Frontend: Add RaptorJIT "Input Tree" IR view

### DIFF
--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -155,10 +155,20 @@ RJITIRInstruction >> gtInspectorIRInstructionIn: composite [
 ]
 
 { #category : #initialization }
+RJITIRInstruction >> gtInspectorInputListingIn: composite [
+	<gtInspectorPresentationOrder: 2>
+	composite fastList
+		title: 'IR Input Listing';
+		display: [ self transitiveInputs asArray];
+		format: #irString.
+
+]
+
+{ #category : #initialization }
 RJITIRInstruction >> gtInspectorInputTreeIn: composite [
 	<gtInspectorPresentationOrder: 3>
 	composite roassal2
-		title: 'Input Tree';
+		title: 'IR Input Tree';
 		initializeView: [ trace irTreeViewOfInstructions: self transitiveInputs ].
 
 ]
@@ -322,6 +332,7 @@ RJITIRInstruction >> isTypeConversion [
 
 { #category : #accessing }
 RJITIRInstruction >> link: aGCtrace [
+	trace := aGCtrace.
 	mode op1mode = #ref ifTrue: [ op1ins := self resolveIR: op1 in: aGCtrace ].
 	mode op2mode = #ref ifTrue: [ op2ins := self resolveIR: op2 in: aGCtrace ].
 	opcode = 'phi' ifTrue: [ 

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -187,6 +187,29 @@ RJITIRInstruction >> gtInspectorInputTreeIn: composite [
 ]
 
 { #category : #initialization }
+RJITIRInstruction >> gtInspectorUsesListingIn: composite [
+	<gtInspectorPresentationOrder: 4>
+	composite fastList
+		title: 'Uses List';
+		display: [ self transitiveUses asArray];
+		format: #irString;
+		addAction: [
+			String streamContents: [ :s |
+				self transitiveUses do: [ :i | 
+					s nextPutAll: i irString; cr ] ]
+		] gtInspectorActionCopyValueToClipboard.
+]
+
+{ #category : #initialization }
+RJITIRInstruction >> gtInspectorUsesTreeIn: composite [
+	<gtInspectorPresentationOrder: 5>
+	composite roassal2
+		title: 'Uses Tree';
+		initializeView: [ trace irTreeViewOfInstructions: self transitiveUses ].
+
+]
+
+{ #category : #initialization }
 RJITIRInstruction >> index [
 	^ index
 ]
@@ -489,6 +512,11 @@ RJITIRInstruction >> stackSlot [
 { #category : #querying }
 RJITIRInstruction >> transitiveInputs [
 	^ trace transitiveInputsOf: self.
+]
+
+{ #category : #querying }
+RJITIRInstruction >> transitiveUses [
+	^ trace transitiveUsesOf: self.
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -138,6 +138,15 @@ RJITIRInstruction >> attributes [
 		}
 ]
 
+{ #category : #roassal }
+RJITIRInstruction >> baseShape [
+	| shape |
+	shape := RTBox new width: 50; height: 20; color: self roassalColor; borderColor: Color lightGray; borderWidth: 1.
+	self isSpilledOntoStack ifTrue: [ shape borderColor: Color black; borderWidth: 2 ].
+	^ shape
+
+]
+
 { #category : #accessing }
 RJITIRInstruction >> constantValue [
 	self shouldBeImplemented.
@@ -160,8 +169,12 @@ RJITIRInstruction >> gtInspectorInputListingIn: composite [
 	composite fastList
 		title: 'Input List';
 		display: [ self transitiveInputs asArray];
-		format: #irString.
-
+		format: #irString;
+		addAction: [
+			String streamContents: [ :s |
+				self transitiveInputs do: [ :i | 
+					s nextPutAll: i irString; cr ] ]
+		] gtInspectorActionCopyValueToClipboard.
 ]
 
 { #category : #initialization }
@@ -319,6 +332,12 @@ RJITIRInstruction >> isNop [
 ]
 
 { #category : #initialization }
+RJITIRInstruction >> isSpilledOntoStack [
+	"Return true if the IR value is stored on the stack instead of in a register."
+	^ stackSlot > 0
+]
+
+{ #category : #initialization }
 RJITIRInstruction >> isStore [
 	^ #(astore hstore ustore fstore xstore) includes: opcode.
 ]
@@ -451,13 +470,12 @@ RJITIRInstruction >> shape [
 "
 	shape := RTCompositeShape new.
 	(op1ins notNil and: [op1ins isConstant]) ifTrue: [
-		shape add: ((RTBox new width: 50; height: 20; borderColor: Color lightGray; color: Color transparent) +
+		shape add: ((RTBox new width: 50; height: 20; borderStyle: #dash; borderColor: Color lightGray; color: Color transparent) +
 			(RTLabel new color: Color veryDarkGray; text: op1ins irRefString)) allOfSameSize ].
 	shape add:
-		(RTBox new width: 50; height: 20; borderColor: Color lightGray; color: self roassalColor) +
-		(RTLabel new color: Color veryDarkGray; text: opcode asString).
+		self baseShape + (RTLabel new color: Color veryDarkGray; text: opcode asString).
 	(op2ins notNil and: [op2ins isConstant]) ifTrue: [
-		shape add: ((RTBox new width: 50; height: 20; borderColor: Color lightGray; color: Color transparent) +
+		shape add: ((RTBox new width: 50; height: 20; borderStyle: #dash; borderColor: Color lightGray; color: Color transparent) +
 				(RTLabel new color: Color veryDarkGray; text: op2ins irRefString)) allOfSameSize ].
 	shape horizontal.
 	^shape

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -158,7 +158,7 @@ RJITIRInstruction >> gtInspectorIRInstructionIn: composite [
 RJITIRInstruction >> gtInspectorInputListingIn: composite [
 	<gtInspectorPresentationOrder: 2>
 	composite fastList
-		title: 'IR Input Listing';
+		title: 'Input List';
 		display: [ self transitiveInputs asArray];
 		format: #irString.
 
@@ -168,7 +168,7 @@ RJITIRInstruction >> gtInspectorInputListingIn: composite [
 RJITIRInstruction >> gtInspectorInputTreeIn: composite [
 	<gtInspectorPresentationOrder: 3>
 	composite roassal2
-		title: 'IR Input Tree';
+		title: 'Input Tree';
 		initializeView: [ trace irTreeViewOfInstructions: self transitiveInputs ].
 
 ]
@@ -310,6 +310,12 @@ RJITIRInstruction >> isMemoryReference [
 { #category : #initialization }
 RJITIRInstruction >> isMisc [
 	^ #(nop base pval gcstep hiop loop use phi rename) includes: opcode.
+]
+
+{ #category : #initialization }
+RJITIRInstruction >> isNop [
+	^ opcode = #nop
+
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -15,7 +15,8 @@ Class {
 		'dwarf',
 		'index',
 		'isPhiOperand',
-		'mode'
+		'mode',
+		'trace'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -146,9 +147,19 @@ RJITIRInstruction >> constantValue [
 RJITIRInstruction >> gtInspectorIRInstructionIn: composite [
 	<gtInspectorPresentationOrder: 1>
 	composite table
+		title: 'Info';
 		display: [ self attributes ];
 		column: 'Key' evaluated: #key width: 100;
 		column: 'Value' evaluated: #value.
+
+]
+
+{ #category : #initialization }
+RJITIRInstruction >> gtInspectorInputTreeIn: composite [
+	<gtInspectorPresentationOrder: 3>
+	composite roassal2
+		title: 'Input Tree';
+		initializeView: [ trace irTreeViewOfInstructions: self transitiveInputs ].
 
 ]
 
@@ -364,6 +375,7 @@ RJITIRInstruction >> register [
 { #category : #initialization }
 RJITIRInstruction >> resolveIR: num in: aGCtrace [
 	| bias idx |
+	trace := aGCtrace.
 	bias := dwarf resolveConstant: 'REF_BIAS'.
 	idx := num - bias.
 	idx >= 0
@@ -437,6 +449,11 @@ RJITIRInstruction >> shape [
 { #category : #initialization }
 RJITIRInstruction >> stackSlot [
 	^ stackSlot
+]
+
+{ #category : #querying }
+RJITIRInstruction >> transitiveInputs [
+	^ trace transitiveInputsOf: self.
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -179,7 +179,7 @@ RJITIRInstruction >> gtInspectorInputListingIn: composite [
 
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorInputTreeIn: composite [
-	<gtInspectorPresentationOrder: 3>
+	<gtInspectorPresentationOrder: 4>
 	composite roassal2
 		title: 'Input Tree';
 		initializeView: [ trace irTreeViewOfInstructions: self transitiveInputs ].
@@ -188,7 +188,7 @@ RJITIRInstruction >> gtInspectorInputTreeIn: composite [
 
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorUsesListingIn: composite [
-	<gtInspectorPresentationOrder: 4>
+	<gtInspectorPresentationOrder: 3>
 	composite fastList
 		title: 'Uses List';
 		display: [ self transitiveUses asArray];

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -72,7 +72,7 @@ RJITTrace >> gtInspectorIRListingIn: composite [
 	<gtInspectorPresentationOrder: 3>
 	composite fastList
 		title: 'IR Listing';
-		display: self irInstructions;
+		display: self irInstructionsNoNop;
 		format: #irString;
 		addAction: [ self irListing ] gtInspectorActionCopyValueToClipboard.
 ]
@@ -114,23 +114,28 @@ RJITTrace >> irConstants [
 { #category : #initializing }
 RJITTrace >> irInstructions [
 	irInstructions isBlock ifTrue: [ 
-		irInstructions := irInstructions value select: [ :ins | ins opcode ~= #nop ].
+		irInstructions := irInstructions value.
 		irInstructions do: [ :ins | ins link: self. ].
  		].
 	^ irInstructions.
 
 ]
 
+{ #category : #accessing }
+RJITTrace >> irInstructionsNoNop [
+	^ self irInstructions reject: #isNop.
+]
+
 { #category : #'as yet unclassified' }
 RJITTrace >> irListing [
 	^ String streamContents: [ :s |
-		self irInstructions do: [ :i | s nextPutAll: i irString; cr. ] ].
+		self irInstructionsNoNop do: [ :i | s nextPutAll: i irString; cr. ] ].
 
 ]
 
 { #category : #'gt-inspector-extension' }
 RJITTrace >> irTreeView [
-	^ self irTreeViewOfInstructions: self irInstructions.
+	^ self irTreeViewOfInstructions: self irInstructionsNoNop.
 ]
 
 { #category : #'gt-inspector-extension' }

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -311,3 +311,17 @@ RJITTrace >> transitiveInputsOf: ins [
 	visit value: ins.
 	^ inputs asArray sort: [ :a :b | a index < b index ].
 ]
+
+{ #category : #querying }
+RJITTrace >> transitiveUsesOf: startIns [
+	| uses candidates graph |
+	uses := Set new.
+	graph := Dictionary new.
+	uses add: startIns.
+	candidates := self irInstructions.
+	candidates do: [ :ins |
+		(uses includesAny: { ins op1ins. ins op2ins }) ifTrue: [ 
+			uses add: ins ].
+	].
+	^ uses asArray sort: [ :a :b | a index < b index ]
+]

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -131,9 +131,23 @@ RJITTrace >> irListing [
 
 { #category : #'gt-inspector-extension' }
 RJITTrace >> irTreeView [
-	| view head loop all separator popup |
-	head := RTGroup new addAll: (self headInstructions collect: #asElement); yourself.
-	loop := RTGroup new addAll: (self loopInstructions collect: #asElement); yourself.
+	^ self irTreeViewOfInstructions: self irInstructions.
+]
+
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> irTreeViewOfInstructions: insns [
+	| headInsns loopInsns view head loop all separator popup |
+	self hasLoop ifTrue: [
+		| loopindex |
+		loopindex := self loop index.
+		headInsns := insns select: [ :i | i index < loopindex ].
+		loopInsns := insns select: [ :i | i index > loopindex ].
+	] ifFalse: [ 
+		headInsns := insns.
+		loopInsns := { }.
+	 ].
+	head := RTGroup new addAll: (headInsns collect: #asElement); yourself.
+	loop := RTGroup new addAll: (loopInsns collect: #asElement); yourself.
 	all := RTGroup new addAll: head; addAll: loop; yourself.
 	separator := RTLabel new elementOn: #'LOOP:'.
 	view := RTView new.
@@ -157,7 +171,7 @@ RJITTrace >> irTreeView [
 		connectFrom: #op2ins.
 	RTDominanceTreeLayout new doNotAttachPoint; on: head.
 	RTDominanceTreeLayout new doNotAttachPoint; on: loop.
-	self hasLoop ifTrue: [ 
+	loopInsns size > 0 ifTrue: [
 		view add: separator.
 		RTVerticalLineLayout on: { head. separator. loop }. ].
 	^ view 
@@ -279,4 +293,17 @@ RJITTrace >> startPrototype [
 { #category : #accessing }
 RJITTrace >> traceno [
 	^ traceno
+]
+
+{ #category : #querying }
+RJITTrace >> transitiveInputsOf: ins [
+	| visit inputs |
+	inputs := Set new.
+	visit := [ :i | 
+		(i isNil or: [ i isConstant or: [ inputs includes: i ] ]) ifFalse: [ 
+			inputs add: i.
+			visit value: i op1ins; value: i op2ins.
+			 ] ].
+	visit value: ins.
+	^ inputs
 ]

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -69,18 +69,17 @@ RJITTrace >> gtInspectorGCTraceIn: composite [
 
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorIRListingIn: composite [
-	| listing |
 	<gtInspectorPresentationOrder: 3>
-	listing := self irListing.
-	composite text
+	composite fastList
 		title: 'IR Listing';
-		display: listing;
-		addAction: [ listing ] gtInspectorActionCopyValueToClipboard.
+		display: self irInstructions;
+		format: #irString;
+		addAction: [ self irListing ] gtInspectorActionCopyValueToClipboard.
 ]
 
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorIRTreeIn: composite [
-	<gtInspectorPresentationOrder: 5>
+	<gtInspectorPresentationOrder: 4>
 	composite roassal2
 		title: 'IR Tree';
 		initializeView: [ self irTreeView ].
@@ -115,7 +114,7 @@ RJITTrace >> irConstants [
 { #category : #initializing }
 RJITTrace >> irInstructions [
 	irInstructions isBlock ifTrue: [ 
-		irInstructions := irInstructions value.
+		irInstructions := irInstructions value select: [ :ins | ins opcode ~= #nop ].
 		irInstructions do: [ :ins | ins link: self. ].
  		].
 	^ irInstructions.
@@ -305,5 +304,5 @@ RJITTrace >> transitiveInputsOf: ins [
 			visit value: i op1ins; value: i op2ins.
 			 ] ].
 	visit value: ins.
-	^ inputs
+	^ inputs asArray sort: [ :a :b | a index < b index ].
 ]


### PR DESCRIPTION
Clicking on an IR instruction now reveals an object with an "Input Tree" view. This shows the subset of the IR tree showing only the inputs to the selected instruction (transitive closure.)

It's a way to "zoom in" on one instruction and see where its input comes from.

Screenshot of clicking on a problematic instruction (unsunk allocation) to see where its value comes from (click to zoom):

![screen shot 2018-04-11 at 12 39 42](https://user-images.githubusercontent.com/13791/38612711-d8a272cc-3d87-11e8-8ca9-aeb67da5ca3d.png)
