### PR TITLE
Frontend: Improve RaptorJIT operand decoding

### DIFF
--- a/frontend/Studio-DWARF/DWARFValue.class.st
+++ b/frontend/Studio-DWARF/DWARFValue.class.st
@@ -73,6 +73,17 @@ DWARFValue >> flashback: aFlashback [
    flashback := aFlashback.
 ]
 
+{ #category : #'as yet unclassified' }
+DWARFValue >> gcval [
+	"Remove tag bits."
+	^ DWARFValue
+		type: type
+		value: (value bitAnd: 16r7FFFFFFFFFFF)
+		address: address
+		flashback: flashback
+
+]
+
 { #category : #accessing }
 DWARFValue >> gtInspectorDWARFIn: composite [
 	<gtInspectorPresentationOrder: 1>

--- a/frontend/Studio-RaptorJIT/Integer.extension.st
+++ b/frontend/Studio-RaptorJIT/Integer.extension.st
@@ -9,3 +9,9 @@ Integer >> asX64RegisterAssignment [
 		) at: self + 1.
 
 ]
+
+{ #category : #'*studio-raptorjit' }
+Integer >> itypeToTypeName [
+	^ #(nil false true str upval thread proto func trace cdata tab udata numx) at: self + 1.
+
+]

--- a/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
@@ -6,7 +6,8 @@ Class {
 		'flashback',
 		'dwarf',
 		'traces',
-		'irModes'
+		'irModes',
+		'ctypes'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -45,6 +46,23 @@ RJITAuditLog >> addRecord: dict [
    type := dict at: 'type'.
    type = 'event' ifTrue:  [ self addEvent: dict ].
    type = 'memory' ifTrue: [ self addMemory: dict ].
+]
+
+{ #category : #visualization }
+RJITAuditLog >> ctypeName: id [
+	^ self ctypes at: id ifAbsent: [ 'CT#', id asString ]
+
+]
+
+{ #category : #visualization }
+RJITAuditLog >> ctypes [
+	ctypes ifNil: [ 
+		ctypes := Dictionary new.
+		events select: [ :e | e class = RJITNewCTypeIDEvent ] thenDo: [ :e |
+			ctypes at: e id put: e desc ]
+	].
+	^ ctypes
+
 ]
 
 { #category : #accessing }
@@ -106,6 +124,7 @@ RJITAuditLog >> makeEventFrom: dict [
    event = 'trace_stop' ifTrue: [ ^RJITTraceStopEvent new from: dict flashback: flashback ].
    event = 'trace_abort' ifTrue: [ ^RJITTraceAbortEvent new from: dict flashback: flashback ].
 	event = 'new_prototype' ifTrue: [  ^RJITNewPrototypeEvent new from: dict flashback: flashback ].
+	event = 'new_ctypeid' ifTrue: [ ^RJITNewCTypeIDEvent new from: dict flashback: flashback ].
    ^RJITUnknownEvent new from: dict flashback: flashback.
 
 ]

--- a/frontend/Studio-RaptorJIT/RJITFlashback.class.st
+++ b/frontend/Studio-RaptorJIT/RJITFlashback.class.st
@@ -83,6 +83,12 @@ RJITFlashback >> decodeArrayOfTypeNamed: typename at: anAddress elements: elems 
 
 ]
 
+{ #category : #accessing }
+RJITFlashback >> decodeCStringAt: anAddress [
+	^ (self decodeStringAt: anAddress size: 1024) copyUpTo: 0 asCharacter.
+
+]
+
 { #category : #decoding }
 RJITFlashback >> decodeGCobjectAt: anAddress [
 	| gcobj |
@@ -103,6 +109,19 @@ RJITFlashback >> decodeJITStateAt: anAddress [
 ]
 
 { #category : #decoding }
+RJITFlashback >> decodeLuaObjectAt: gcref [
+	| itype type addr |
+	itype := gcref bitShift: -47.
+	type := itype itypeToTypeName.
+	addr := gcref bitAnd: 16r7FFFFFFFFFFF. "mask off tag bits"
+	type = nil ifTrue: [ ^nil ].
+	type = false ifTrue: [ ^false ].
+	type = true ifTrue: [ ^true ].
+	self halt.
+
+]
+
+{ #category : #decoding }
 RJITFlashback >> decodeLuaStringAt: anAddress [
 	| gcstr |
 	gcstr := self decodeTypeNamed: #GCstr at: anAddress asInteger.
@@ -111,6 +130,7 @@ RJITFlashback >> decodeLuaStringAt: anAddress [
 
 { #category : #accessing }
 RJITFlashback >> decodeStringAt: anAddress size: size [
+	[  size < 65536 ] assert.
 	^ (self bytesAt: anAddress size: size) asString
 
 ]

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -238,6 +238,7 @@ RJITIRInstruction >> irIns: dwValue [
 
 { #category : #printing }
 RJITIRInstruction >> irRefString [
+	"This is a hairy function that should be refactored once its ideal structure becomes clear."
 	self isConstant ifFalse: [ 
 		^ index printStringLength: 4 padded: true.
 	].
@@ -245,14 +246,37 @@ RJITIRInstruction >> irRefString [
 	(opcode = #kpri and: type = #true)  ifTrue: [ ^ 'T' ].
 	(opcode = #kpri and: type = #false) ifTrue: [ ^ 'F' ].
 	(opcode = #kpri and: type = #nil)   ifTrue: [ ^ 'NULL' ].
+	(opcode = #kgc)    ifTrue: [
+		| ptr |
+		ptr := (irIns flashback decodeTypeNamed: #uint64_t at: irIns address + 8) value.
+		type = #str ifTrue: [
+			[ ^ '''', (irIns flashback decodeLuaStringAt: ptr), '''' ]
+				on: Error do: [ ] ].
+		type = #func ifTrue: [ 
+			[ | gcfunc protoPtr proto |
+				gcfunc := irIns flashback decodeTypeNamed: #GCfunc at: ptr.
+				protoPtr := ((gcfunc child: #l) value child: #pc) value value - (irIns dwarf typeNamed: #GCproto) byteSize.
+				proto := irIns flashback decodeGCprotoAt: protoPtr.
+				^ proto sourceName, ':', (proto bytecodeLine: 0) asString. ] on: RJITFlashbackDataMissing do: [] ] ].
+	opcode = #kint64 ifTrue: [
+		| v |
+		v := irIns flashback decodeTypeNamed: 'uint64_t' at: irIns address + 8.
+		^ v value asString, 'LL' ].
+	opcode = #knull ifTrue: [ ^'NULL' ].
+	(#(kptr kkptr) includes: opcode) ifTrue: [
+		| v |
+		v := irIns flashback decodeTypeNamed: 'uint64_t' at: irIns address + 8.
+		^ '@0x', (v value radix: 16).		
+	].
 	opcode = #kint ifTrue: [ ^ (op12 sign = -1 ifTrue: ['-'] ifFalse: ['+']) , op12 printString ].
+	opcode = #kslot ifTrue: [  op1ins ifNotNil: [ ^ op1ins irRefString ] ].
 	"XXX NYI"
 	^ '<' , type , '>'
 ]
 
 { #category : #printing }
 RJITIRInstruction >> irRegisterString [
-	self isSunk ifTrue: [ ^ '{sink' ].
+	self isSunk ifTrue: [ ^ '{sink}' ].
 	stackSlot > 0 ifTrue: [ ^ '[{1}]' format: { stackSlot radix: 16 } ].
 	register < 128 ifTrue: [ ^ register asX64RegisterAssignment ].
 	^ ''. "None"
@@ -272,7 +296,7 @@ RJITIRInstruction >> irString [
 			nextPutAll: (self isGuardedAssertion ifTrue: '>' ifFalse: ' ');
 			nextPutAll: (isPhiOperand ifTrue: '+' ifFalse: ' ');
 			space;
-			nextPutAll: (self type = #nil ifTrue: [ '   ' ] ifFalse: [ self type ]);
+			nextPutAll: ((self type = #nil ifTrue: [ '' ] ifFalse: [ self type ]) padRightTo: 6);
 			space;
 			nextPutAll: (opcode padRightTo: 6).
 		op1ins ifNotNil: [ s space; nextPutAll: (op1ins irRefString padRightTo: 5) ].
@@ -394,6 +418,19 @@ RJITIRInstruction >> op1 [
 ]
 
 { #category : #accessing }
+RJITIRInstruction >> op12 [
+	^ op12
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> op1InlineString [
+	(#(cnew cnewi) includes: opcode) ifTrue: [
+		^ irIns flashback auditLog ctypeName: op1ins op12 ].
+	(op1ins ~= nil and: [ op1ins isConstant]) ifTrue: [ ^ op1ins irRefString ].
+	^ nil
+]
+
+{ #category : #accessing }
 RJITIRInstruction >> op1ins [
 	^ op1ins
 ]
@@ -401,6 +438,14 @@ RJITIRInstruction >> op1ins [
 { #category : #accessing }
 RJITIRInstruction >> op2 [
 	^ op2
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> op2InlineString [
+	(#(urefo urefc) includes: opcode) ifTrue: [ 
+		^ '#', op2 asString ].
+	(op2ins ~= nil and: [ op2ins isConstant ]) ifTrue: [ ^ op2ins irRefString ].
+	^ nil
 ]
 
 { #category : #accessing }
@@ -492,14 +537,14 @@ RJITIRInstruction >> shape [
  ].
 "
 	shape := RTCompositeShape new.
-	(op1ins notNil and: [op1ins isConstant]) ifTrue: [
+	self op1InlineString ifNotNil: [ :str |
 		shape add: ((RTBox new width: 50; height: 20; borderStyle: #dash; borderColor: Color lightGray; color: Color transparent) +
-			(RTLabel new color: Color veryDarkGray; text: op1ins irRefString)) allOfSameSize ].
+			(RTLabel new color: Color veryDarkGray; text: str)) allOfSameSize ].
 	shape add:
 		self baseShape + (RTLabel new color: Color veryDarkGray; text: opcode asString).
-	(op2ins notNil and: [op2ins isConstant]) ifTrue: [
+	self op2InlineString ifNotNil: [ :str |
 		shape add: ((RTBox new width: 50; height: 20; borderStyle: #dash; borderColor: Color lightGray; color: Color transparent) +
-				(RTLabel new color: Color veryDarkGray; text: op2ins irRefString)) allOfSameSize ].
+				(RTLabel new color: Color veryDarkGray; text: str)) allOfSameSize ].
 	shape horizontal.
 	^shape
 ]

--- a/frontend/Studio-RaptorJIT/RJITNewCTypeIDEvent.class.st
+++ b/frontend/Studio-RaptorJIT/RJITNewCTypeIDEvent.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #RJITNewCTypeIDEvent,
+	#superclass : #RJITEvent,
+	#instVars : [
+		'id',
+		'desc'
+	],
+	#category : #'Studio-RaptorJIT'
+}
+
+{ #category : #accessing }
+RJITNewCTypeIDEvent >> desc [
+	^ desc
+]
+
+{ #category : #initialization }
+RJITNewCTypeIDEvent >> from: dict flashback: aFlashback [
+	flashback := aFlashback.
+	id := dict at: #id.
+	desc := dict at: #desc.
+]
+
+{ #category : #accessing }
+RJITNewCTypeIDEvent >> id [
+	^ id
+]

--- a/frontend/Studio-RaptorJIT/RJITPrototype.class.st
+++ b/frontend/Studio-RaptorJIT/RJITPrototype.class.st
@@ -61,3 +61,11 @@ RJITPrototype >> programCounterLine: pc [
 RJITPrototype >> sourceName [
 	^ sourceName trimLeft: [ :x | x = $@ or: x = $= ]
 ]
+
+{ #category : #'as yet unclassified' }
+RJITPrototype >> upvalueName: index [
+	| uvinfoPtr |
+	uvinfoPtr := (gcproto child: #uvinfo) value value.
+	^ gcproto flashback decodeCStringAt: uvinfoPtr + (index * 8).
+
+]

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -24,6 +24,11 @@ RJITTrace >> exitno [
 	^ exitno
 ]
 
+{ #category : #accessing }
+RJITTrace >> flashback [
+	^ gctrace flashback
+]
+
 { #category : #'instance creation' }
 RJITTrace >> from: aGCtrace withExistingTraces: traces [
 	| flashback bias irAddress nk |
@@ -107,7 +112,9 @@ RJITTrace >> headInstructions [
 
 { #category : #accessing }
 RJITTrace >> irConstants [
-	irConstants isBlock ifTrue: [ irConstants := irConstants value. ].
+	irConstants isBlock ifTrue: [
+		irConstants := irConstants value.
+		irConstants select: #notNil thenDo: [ :ins | ins link: self ] ].
 	^ irConstants
 ]
 


### PR DESCRIPTION
Generic operand strings like 'str' and 'func' and 'p32' are now replaced by meaningful descriptions of the referenced objects.

This only happens with a version of RaptorJIT that includes sufficient debug information in the auditlog (e.g. lukego/raptorjit@486f720ffbbccd73d5b5a91f0f6dbde6b002aebc). Logs from older RaptorJIT versions will fallback to displaying generic strings.

Screenshot showing function location and hashtable string constant key decoding:

![screen shot 2018-04-13 at 09 40 19](https://user-images.githubusercontent.com/13791/38722725-2100d98c-3eff-11e8-90e3-ee23030119ad.png)
