### PR TITLE
Frontend: RaptorJIT IR Listings are now tables

### DIFF
--- a/frontend/Studio-RaptorJIT/Collection.extension.st
+++ b/frontend/Studio-RaptorJIT/Collection.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #Collection }
+
+{ #category : #'*studio-raptorjit' }
+Collection >> irListViewIn: composite title: aTitle [
+	"For a Collection of RJITIrInstruction instances."
+	composite fastTable 
+		title: aTitle;
+		display: self;
+		column: 'Num' evaluated: #irRefString width: 40;
+		column: 'Loc' evaluated: #irRegisterString width: 40;
+		column: 'Flags' evaluated: #irFlagsString width: 40;
+		column: 'Opcode' evaluated: #opcode width: 50;
+		column: 'Operands' evaluated: #operandsString width: 1000;
+		addAction: [
+			String streamContents: [ :s |
+				self do: [ :i | 
+					s nextPutAll: i irString; cr ] ]
+		] gtInspectorActionCopyValueToClipboard.
+
+]

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -166,15 +166,8 @@ RJITIRInstruction >> gtInspectorIRInstructionIn: composite [
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorInputListingIn: composite [
 	<gtInspectorPresentationOrder: 2>
-	composite fastList
-		title: 'Input List';
-		display: [ self transitiveInputs asArray];
-		format: #irString;
-		addAction: [
-			String streamContents: [ :s |
-				self transitiveInputs do: [ :i | 
-					s nextPutAll: i irString; cr ] ]
-		] gtInspectorActionCopyValueToClipboard.
+	self transitiveInputs irListViewIn: composite title: 'Input List'.
+
 ]
 
 { #category : #initialization }
@@ -189,15 +182,8 @@ RJITIRInstruction >> gtInspectorInputTreeIn: composite [
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorUsesListingIn: composite [
 	<gtInspectorPresentationOrder: 3>
-	composite fastList
-		title: 'Uses List';
-		display: [ self transitiveUses asArray];
-		format: #irString;
-		addAction: [
-			String streamContents: [ :s |
-				self transitiveUses do: [ :i | 
-					s nextPutAll: i irString; cr ] ]
-		] gtInspectorActionCopyValueToClipboard.
+	self transitiveUses irListViewIn: composite title: 'Uses List'.
+
 ]
 
 { #category : #initialization }
@@ -217,6 +203,13 @@ RJITIRInstruction >> index [
 { #category : #initialization }
 RJITIRInstruction >> index: i [
 	index := i
+]
+
+{ #category : #printing }
+RJITIRInstruction >> irFlagsString [
+	^ (self isGuardedAssertion ifTrue: '>' ifFalse: ' ') ,
+		(isPhiOperand ifTrue: '+' ifFalse: ' ').
+
 ]
 
 { #category : #initialization }
@@ -456,6 +449,26 @@ RJITIRInstruction >> op2ins [
 { #category : #accessing }
 RJITIRInstruction >> opcode [
 	^ opcode
+]
+
+{ #category : #'as yet unclassified' }
+RJITIRInstruction >> operand1String [
+	^ String streamContents: [ :s |
+		op1ins ifNotNil: [ s nextPutAll: (op1ins irRefString padRightTo: 5) ].
+		mode op1mode = #lit ifTrue: [ s space; nextPutAll: '#' , op1 printString ]. ]
+]
+
+{ #category : #'as yet unclassified' }
+RJITIRInstruction >> operand2String [
+	^ String streamContents: [ :s |
+		op2ins ifNotNil: [ s nextPutAll: (op2ins irRefString padRightTo: 5) ].
+		mode op2mode = #lit ifTrue: [ s space; nextPutAll: '#' , op2 printString ]. ]
+]
+
+{ #category : #'as yet unclassified' }
+RJITIRInstruction >> operandsString [
+	^ self operand1String , String space, self operand2String.
+
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -75,11 +75,8 @@ RJITTrace >> gtInspectorGCTraceIn: composite [
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorIRListingIn: composite [
 	<gtInspectorPresentationOrder: 3>
-	composite fastList
-		title: 'IR Listing';
-		display: self irInstructionsNoNop;
-		format: #irString;
-		addAction: [ self irListing ] gtInspectorActionCopyValueToClipboard.
+	self irInstructionsNoNop irListViewIn: composite title: 'IR List'.
+
 ]
 
 { #category : #'gt-inspector-extension' }


### PR DESCRIPTION
The IR listing is now a table with discrete columns. This is handy for alignment and for grouping instructions by sorting them.

The flat textual representation is accessible via the Save icon. This loads it onto the clipboard so you can paste it into an editor.

Screenshot:

![screen shot 2018-04-13 at 12 20 25](https://user-images.githubusercontent.com/13791/38729972-173d7ae8-3f15-11e8-8edd-b327744075e1.png)
