### PR TITLE
Frontend: RaptorJIT root trace link '->42' instead of 'root'

### DIFF
--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -105,7 +105,7 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 					sorted: [ :x :y | x samples > y samples ];
 					column: 'Trace' evaluated: #traceno width: 160;
 					column: 'Samples' evaluated: #samples width: 60;
-					column: 'Link' evaluated: #linktype width: 60;
+					column: 'Link' evaluated: #linkname width: 60;
 					column: 'Mcode' evaluated: (percent value: #mcodePercent) width: w;
 					column: 'VM' evaluated: (percent value: #vmPercent) width: w;
 					column: 'GC' evaluated: (percent value: #gcPercent) width: w;

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -215,6 +215,14 @@ RJITTrace >> link [
 ]
 
 { #category : #accessing }
+RJITTrace >> linkname [
+	^linktype = #root
+		ifTrue: [ '->', link traceno asString ]
+		ifFalse: linktype.
+
+]
+
+{ #category : #accessing }
 RJITTrace >> linktype [
 	^ linktype
 ]

--- a/frontend/Studio-RaptorJIT/RJITTraceWithProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTraceWithProfile.class.st
@@ -25,6 +25,11 @@ RJITTraceWithProfile >> gcPercent [
 ]
 
 { #category : #accessing }
+RJITTraceWithProfile >> linkname [
+	^ trace linkname
+]
+
+{ #category : #accessing }
 RJITTraceWithProfile >> linktype [
 	^ trace linktype
 ]


### PR DESCRIPTION
Specify which root trace is linked.