### PR TITLE
Frontend: Add "Trace List" and "Trace Map" and "Trace Info"

### DIFF
--- a/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
@@ -7,7 +7,8 @@ Class {
 		'dwarf',
 		'traces',
 		'irModes',
-		'ctypes'
+		'ctypes',
+		'process'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -127,6 +128,16 @@ RJITAuditLog >> makeEventFrom: dict [
 	event = 'new_ctypeid' ifTrue: [ ^RJITNewCTypeIDEvent new from: dict flashback: flashback ].
    ^RJITUnknownEvent new from: dict flashback: flashback.
 
+]
+
+{ #category : #accessing }
+RJITAuditLog >> process [
+	^ process
+]
+
+{ #category : #accessing }
+RJITAuditLog >> process: aRJITProcess [ 
+	process := aRJITProcess
 ]
 
 { #category : #visualization }

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -467,6 +467,7 @@ RJITIRInstruction >> operand2String [
 
 { #category : #'as yet unclassified' }
 RJITIRInstruction >> operandsString [
+	opcode = #loop ifTrue: [ ^ '-----------------------------------------' ].
 	^ self operand1String , String space, self operand2String.
 
 ]

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -39,6 +39,7 @@ RJITProcess >> fromPath: aPath [
 	[ dwarfPath isFile and: auditPath isFile ] assertWithDescription:
 		'JIT audit log not found'.
 	auditLog := RJITAuditLog loadFromFileNamed: auditPath pathString withDWARF: (DWARF loadFromFileNamed: dwarfPath pathString).
+	auditLog process: self.
 	"Load VMProfile data with progress monitoring."
 	vmprofiles := OrderedCollection new.
 	(path / 'vmprofile') children
@@ -50,7 +51,7 @@ RJITProcess >> fromPath: aPath [
 
 { #category : #accessing }
 RJITProcess >> gtInspectorEventsIn: composite [
-	<gtInspectorPresentationOrder: 2>
+	<gtInspectorPresentationOrder: 6>
 	composite fastList
 		title: 'Events';
 		display: [ self auditLog events reverse ];
@@ -67,9 +68,37 @@ RJITProcess >> gtInspectorFilesIn: composite [
 
 ]
 
+{ #category : #accessing }
+RJITProcess >> gtInspectorTraceListIn: composite [
+	<gtInspectorPresentationOrder: 1>
+	composite fastTable
+		title: 'Trace List';
+		display: [ self auditLog traces ];
+		column: 'Nr' evaluated: [ :tr | tr traceno asString ] width: 50 tags: nil sortedBy: #traceno descending;
+		column: 'Parent' evaluated: #parentname width: 50 tags: nil sortedBy: [ :a :b |
+			| an bn |
+			an := a parent ifNil: 0 ifNotNil: #traceno.
+			bn := b parent ifNil: 0 ifNotNil: #traceno.
+			an < bn ];
+		column: 'Link' evaluated: #linkname width: 80;
+		column: 'Samples' evaluated: #totalSamples width: 80 tags: nil sortedBy: [ :a :b | (self totalSamplesFor: a) > (self totalSamplesFor: b) ];
+		column: 'Start line' evaluated: #startLine width: 800;
+		installExportToCSV.
+
+]
+
+{ #category : #accessing }
+RJITProcess >> gtInspectorTraceMapIn: composite [
+	<gtInspectorPresentationOrder: 2>
+	composite roassal2
+		title: 'Trace Map';
+		initializeView: [ self traceMapView ].
+
+]
+
 { #category : #'instance creation' }
 RJITProcess >> gtInspectorVMProfilesIn: composite [
-	<gtInspectorPresentationOrder: 1>
+	<gtInspectorPresentationOrder: 5>
 	| w percent |
 	w := 50. "width of numeric columns"
 	^ composite tabulator
@@ -115,6 +144,61 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 			t transmit toOutsidePort: #selection; from: #traces port: #selection transformed: #trace.
 			].
 
+]
+
+{ #category : #accessing }
+RJITProcess >> totalSamples [
+	^ vmprofiles sum: #total
+
+]
+
+{ #category : #accessing }
+RJITProcess >> totalSamplesFor: trace [ 
+	^ vmprofiles sum: [ :p | (p trace: trace) all]
+]
+
+{ #category : #visualization }
+RJITProcess >> traceMapView [
+	| shape roots rootElems rootBoxes view popup |
+	view := RTView new.
+
+"	roots := {((self traces select: #isRootTrace) select: [ :tr | tr children size > 3 ]) atRandom}."
+
+	popup := (RTPopup new
+		text: #printString;
+		alphaPopupBackground: 1.0;
+		borderColor: Color black;
+		backgroundColor: Color white).
+
+	roots := self traces select: #isRootTrace.
+	rootBoxes := (RTBox new color: Color transparent; borderWidth: 1) elementsOn: (roots collect: [ :tr | tr ]).
+	view addAll: rootBoxes.
+	RTNest new for: rootBoxes add: [ :group :tr |
+		| traces elements edges |
+		traces := tr withAllChildren.
+		elements := traces collect: #asElement.
+		group addAll: elements.
+		group @ popup.
+		edges := RTEdgeBuilder new
+						view: group;
+						objects: traces;
+						shape: (RTLine new);
+						connectToAll: #children.
+		RTHorizontalTreeLayout on: elements edges: edges.
+		].
+
+	RTVerticalLineLayout new on: rootBoxes.
+
+	view @ RTZoomableBoxView.
+	view @ RTDoubleScrollBar.
+
+	^ view
+
+]
+
+{ #category : #accessing }
+RJITProcess >> traces [
+	^ auditLog traces
 ]
 
 { #category : #visualization }

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -20,6 +20,37 @@ Class {
 }
 
 { #category : #accessing }
+RJITTrace >> allChildren [
+	| set children |
+	set := Set new.
+	children := self children.
+	children do: [ :c | set addAll: c allChildren ].
+	set addAll: children.
+	^ set.
+
+]
+
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> asElement [
+	| box |
+	box := RTBox new size: [ :tr | tr numberOfIrInstructions sqrt * 5 ];
+					borderColor: Color black;
+					color: [ :tr | Color red alpha: ((self totalSamples) / self process totalSamples) ].
+	self isRootTrace ifTrue: [ box borderColor: Color black; borderWidth: 2 ].
+	^ box	+ (RTLabel new color: Color black; text: #traceno) elementOn: self.	
+]
+
+{ #category : #'as yet unclassified' }
+RJITTrace >> bytecodes [
+	self shouldBeImplemented.
+]
+
+{ #category : #accessing }
+RJITTrace >> children [
+	^ self process traces select: [ :tr | tr parent = self ]
+]
+
+{ #category : #accessing }
 RJITTrace >> exitno [
 	^ exitno
 ]
@@ -54,7 +85,7 @@ RJITTrace >> from: aGCtrace withExistingTraces: traces [
 
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorBytecodesIn: composite [
-	<gtInspectorPresentationOrder: 1>
+	<gtInspectorPresentationOrder: 2>
 	jitState ifNil: [ ^nil ].
 	jitState gtInspectorBytecodesIn: composite.
 
@@ -88,6 +119,35 @@ RJITTrace >> gtInspectorIRTreeIn: composite [
 
 ]
 
+{ #category : #accessing }
+RJITTrace >> gtInspectorInfoIn: composite [
+	<gtInspectorPresentationOrder: 1>
+	composite tabulator
+		title: 'Info';
+		with: [ :t |
+			t row: #info; row: #profile.
+			t transmit to: #info; andShow: [ :a |
+				a fastTable
+					title: 'Trace Attributes';
+					display: [ self info ];
+					column: 'Name' evaluated: #key width: 100;
+					column: 'Value' evaluated: #value width: 600.
+				].
+			t transmit to: #profile; andShow: [ :a |
+				| tab |
+				tab := a fastTable 
+					title: 'Profiler Samples';
+					display: [ self process vmprofiles collect: [ :p | p trace: self ] ];
+					format: #asString;
+					sorted: [ :x :y | x all > y all ];
+					column: 'Profile' evaluated: [ :pt | pt vmprofile name ].
+				"#( all vm mcode gc )"
+				#( interp c igc exit record opt asm head loop ffi jgc ) do: [ :key |
+					tab column: key asString evaluated: key width: 45 ].
+				].
+	].
+]
+
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorJITIn: composite [
 	<gtInspectorPresentationOrder: 5>
@@ -105,6 +165,23 @@ RJITTrace >> hasLoop [
 { #category : #initializing }
 RJITTrace >> headInstructions [
 	^ self irInstructions copyUpTo: self loop.
+]
+
+{ #category : #accessing }
+RJITTrace >> info [
+	^{
+		'Summary' -> self printString.
+		'TraceNo' -> traceno.
+		'Root' -> (root = self ifTrue: [ '(self)' ] ifFalse: [ root ]).
+		'Parent' -> parent.
+		'Link' -> (link ifNil: linktype).
+		'Start Line' -> self startLine.
+		'IR Instructions' -> self numberOfIrInstructions.
+		'Profiler samples' -> ('{1} ({2}%)' format: {
+			self totalSamples.
+			(self totalSamples * 100.0 / self process totalSamples) printShowingDecimalPlaces: 1.
+		}).
+	}
 ]
 
 { #category : #accessing }
@@ -247,6 +324,24 @@ RJITTrace >> parent [
 	^parent
 ]
 
+{ #category : #accessing }
+RJITTrace >> parentname [
+	^ parent ifNil: [ '' ] ifNotNil: [ parent traceno asString , '/' , exitno asString ].
+]
+
+{ #category : #printing }
+RJITTrace >> printOn: aStream [
+	aStream nextPutAll: 'trace '.
+	aStream nextPutAll: traceno asString.
+	self isSideTrace ifTrue: [ aStream nextPutAll: '/' , self parentname ].
+	aStream nextPutAll: ' from ', self startLine.
+]
+
+{ #category : #accessing }
+RJITTrace >> process [
+	^ gctrace flashback auditLog process
+]
+
 { #category : #initializing }
 RJITTrace >> roassal [
 	| view elements head loop headIns loopIns insShape shapeContainer shapeIns headLabel loopLabel line border |
@@ -307,6 +402,12 @@ RJITTrace >> startPrototype [
 ]
 
 { #category : #accessing }
+RJITTrace >> totalSamples [
+	^ self process totalSamplesFor: self.
+
+]
+
+{ #category : #accessing }
 RJITTrace >> traceno [
 	^ traceno
 ]
@@ -336,4 +437,10 @@ RJITTrace >> transitiveUsesOf: startIns [
 			uses add: ins ].
 	].
 	^ uses asArray sort: [ :a :b | a index < b index ]
+]
+
+{ #category : #accessing }
+RJITTrace >> withAllChildren [
+	^ self allChildren add: self; yourself.
+
 ]

--- a/frontend/Studio-RaptorJIT/RJITTraceEvent.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTraceEvent.class.st
@@ -19,7 +19,8 @@ RJITTraceEvent >> gcTraceWithExistingTraces: traces [
 
 { #category : #'gt-inspector-extension' }
 RJITTraceEvent >> gtInspectorIRTreeIn: composite [
-	<gtInspectorPresentationOrder: 7>
+	"<gtInspectorPresentationOrder: 7>"
+	"XXX Failing with a decoding error. Have to troubleshoot before enabling this view."
 	self trace gtInspectorIRTreeIn: composite.
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
@@ -49,7 +49,7 @@ RJITVMProfile >> gcPercent [
 
 { #category : #initialization }
 RJITVMProfile >> gtInspectorHotTracesIn: composite [
-	<gtInspectorPresentationOrder: 5>
+	"<gtInspectorPresentationOrder: 5>"
 	process ifNil: [ ^nil ].
 	^ composite roassal2
 		view: (process visualizeTraces: process auditLog traces withProfile: self);
@@ -64,7 +64,7 @@ RJITVMProfile >> loadFromFileNamed: aFilename [
 	[ (data unsignedShortAt: 5) = 4 ] assert.
 	index := 8.
 	traces := (0 to: 4096) collect: [ :tr | | trace |
-		trace := RJITVMProfileTrace new id: tr.
+		trace := RJITVMProfileTrace new id: tr; vmprofile: self; yourself.
 		#(interp: c: igc: exit: record: opt: asm: head: loop: jgc: ffi:) do: [ :selector |
 			trace perform: selector with: (data unsignedLongLongAt: index+1).
 			index := index + 8. ].

--- a/frontend/Studio-RaptorJIT/RJITVMProfileTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfileTrace.class.st
@@ -13,7 +13,8 @@ Class {
 		'loop',
 		'jgc',
 		'ffi',
-		'id'
+		'id',
+		'vmprofile'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -185,4 +186,14 @@ RJITVMProfileTrace >> vm [
 RJITVMProfileTrace >> vmPercent [
 	^ self vm * 100.0 / self all.
 
+]
+
+{ #category : #accessing }
+RJITVMProfileTrace >> vmprofile [
+	^ vmprofile
+]
+
+{ #category : #accessing }
+RJITVMProfileTrace >> vmprofile: aVMProfile [
+	vmprofile := aVMProfile
 ]


### PR DESCRIPTION
Extend the RaptorJIT view of traces (both collectively and individually.)

Trace List (simple table of traces):

![screenshot 2018-04-20 11 31 47](https://user-images.githubusercontent.com/13791/39043796-9e3c1670-448e-11e8-987d-8050a5a6ac40.png)

Trace Map (still rough):

![screenshot 2018-04-20 11 32 24](https://user-images.githubusercontent.com/13791/39043795-9e212f5e-448e-11e8-838b-5c77457593e9.png)

Trace Info (summary of one trace):

![screenshot 2018-04-20 11 32 45](https://user-images.githubusercontent.com/13791/39043794-9e04fb7c-448e-11e8-82f2-d9041301dee0.png)
