### PR TITLE
RaptorJIT frontend improvements

### DIFF
--- a/backend/disasm/default.nix
+++ b/backend/disasm/default.nix
@@ -5,16 +5,13 @@ writeScriptBin "disasm" ''
   #!/usr/bin/env bash
   set -e
 
-  [ $# == 1 ] || (echo "Usage: $0 <startaddress>"; exit 1)
-  start=$1
+  [ $# == 2 ] || (echo "Usage: disasm <file> <startaddress>"; exit 1)
+  file="$1"
+  start="$2"
 
-  tmp=$(mktemp)
-  trap "rm -f $tmp" EXIT
-
-  cat > $tmp
   ${binutils}/bin/objdump -mi386 -M intel -M intel-mnemonic -M x86-64 \
           --adjust-vma=$start \
           --no-show-raw-insn \
-          -D -b binary $tmp \
+          -D -b binary "$file" \
     | ${gnugrep}/bin/grep -E '^ *[0-9a-fA-F]+:'
 ''

--- a/backend/disasm/default.nix
+++ b/backend/disasm/default.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+with pkgs; with stdenv;
+
+writeScriptBin "disasm" ''
+  #!/usr/bin/env bash
+  set -e
+
+  [ $# == 1 ] || (echo "Usage: $0 <startaddress>"; exit 1)
+  start=$1
+
+  tmp=$(mktemp)
+  trap "rm -f $tmp" EXIT
+
+  cat > $tmp
+  ${binutils}/bin/objdump -mi386 -M intel -M intel-mnemonic -M x86-64 \
+          --adjust-vma=$start \
+          --no-show-raw-insn \
+          -D -b binary $tmp \
+    | ${gnugrep}/bin/grep -E '^ *[0-9a-fA-F]+:'
+''

--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -17,7 +17,7 @@
 with pkgs; with builtins; with stdenv;
 
 rec {
-  raptorjit = llvmPackages_4.stdenv.mkDerivation {
+  raptorjit = stdenv.mkDerivation {
     name = "raptorjit-auditlog";
     nativeBuildInputs = [ gcc luajit ];
     src = fetchFromGitHub {
@@ -76,7 +76,7 @@ rec {
       product = inspect raw;
     };
   # Convenience wrappers
-  run = luaSource: runCode (writeScript "script.lua" luaSource);
+  run = luaSource: runCode (writeTextDir "script.lua" luaSource);
   runTarball = url: runCode (fetchTarball url);
   runFile = runCode;
   runDirectory = runCode;

--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -23,8 +23,8 @@ rec {
     src = fetchFromGitHub {
       owner = "lukego";
       repo = "raptorjit";
-      rev = "840643881d676459f1c1d77dbd41600b682f8d56";
-      sha256 = "0mhs89kxf45jjy6rwkjblq22jjg9phficlmr7l8rfdx70k4mass4";
+      rev = "92955dc8387c4980ebbc0656347fcc74d7ac2f04";
+      sha256 = "02jljk5nvgkqlz24cg98lipz2k2vxzlahch9a9fg93r3bi18pi9c";
     };
     installPhase = ''
       install -D src/raptorjit $out/bin/raptorjit

--- a/bin/studio
+++ b/bin/studio
@@ -37,7 +37,7 @@ runstudio() {
   cmd="$2"
   export TMPDIR=$(mktemp -d)
   trap "rm -rf $TMPDIR" EXIT
-  nix-shell $nixopts --run "$cmd" -E - <<EOF
+  nix-shell $nixopts --run "STUDIO_PATH=$studio $cmd" -E - <<EOF
     with import $studio;
     runCommandNoCC "studio" {
       nativeBuildInputs = [ nixUnstable xorg.xauth perl disasm $attr ];

--- a/bin/studio
+++ b/bin/studio
@@ -40,7 +40,7 @@ runstudio() {
   nix-shell $nixopts --run "$cmd" -E - <<EOF
     with import $studio;
     runCommandNoCC "studio" {
-      nativeBuildInputs = [ nixUnstable xorg.xauth perl $attr ];
+      nativeBuildInputs = [ nixUnstable xorg.xauth perl disasm $attr ];
     } ""
 EOF
 }

--- a/frontend/Studio-DWARF/DWARF.class.st
+++ b/frontend/Studio-DWARF/DWARF.class.st
@@ -36,6 +36,22 @@ DWARF >> enumerationTypeWith: aName [
 ]
 
 { #category : #initialization }
+DWARF >> loadFromBinaryFileNamed: fileName [
+	| res |
+	res := Nix build: 'with import <studio>; dwarfish.elf2json ', fileName.
+	self loadFromFileNamed: res first.
+
+]
+
+{ #category : #initialization }
+DWARF >> loadFromByteArray: array [
+	| tmp |
+	tmp := FileReference newTempFilePrefix: 'dwarf-' suffix: '.dwo'.
+	tmp writeStream binary nextPutAll: array; close.
+	self loadFromBinaryFileNamed: tmp pathString.
+]
+
+{ #category : #initialization }
 DWARF >> loadFromFileNamed: fileName [
 	| references  |
 	json := (NeoJSONReader on: (FileStream readOnlyFileNamed: fileName)) next.

--- a/frontend/Studio-DWARF/DWARF.class.st
+++ b/frontend/Studio-DWARF/DWARF.class.st
@@ -39,7 +39,7 @@ DWARF >> enumerationTypeWith: aName [
 DWARF >> loadFromBinaryFileNamed: fileName [
 	| res |
 	[
-		res := Nix build: 'with import <studio>; dwarfish.elf2json ', fileName.
+		res := Nix build: 'with import <studio>; dwarfish.elf2json ', fileName
 	] asJob title: 'Preprocessing DWARF definitions'; run.
 	self loadFromFileNamed: res first.
 
@@ -47,8 +47,10 @@ DWARF >> loadFromBinaryFileNamed: fileName [
 
 { #category : #initialization }
 DWARF >> loadFromByteArray: array [
-	| tmp |
-	tmp := FileReference newTempFilePrefix: 'dwarf-' suffix: '.dwo'.
+	| tmpdir hash tmp |
+	hash := (SHA256 hashMessage: array) hex.
+	tmpdir := FileLocator temp asFileReference.
+	tmp := tmpdir / ('dwarf-',hash,'.dwo').
 	tmp writeStream binary nextPutAll: array; close.
 	self loadFromBinaryFileNamed: tmp pathString.
 ]

--- a/frontend/Studio-DWARF/DWARF.class.st
+++ b/frontend/Studio-DWARF/DWARF.class.st
@@ -38,7 +38,9 @@ DWARF >> enumerationTypeWith: aName [
 { #category : #initialization }
 DWARF >> loadFromBinaryFileNamed: fileName [
 	| res |
-	res := Nix build: 'with import <studio>; dwarfish.elf2json ', fileName.
+	[
+		res := Nix build: 'with import <studio>; dwarfish.elf2json ', fileName.
+	] asJob title: 'Preprocessing DWARF definitions'; run.
 	self loadFromFileNamed: res first.
 
 ]

--- a/frontend/Studio-DWARF/DWARFEnumerationType.class.st
+++ b/frontend/Studio-DWARF/DWARFEnumerationType.class.st
@@ -22,7 +22,18 @@ DWARFEnumerationType >> decode: byteArray address: address flashback: flashback 
 { #category : #initialization }
 DWARFEnumerationType >> from: dict via: references [
 	name := dict at: 'name' ifAbsent: [nil].
-	type := references at: (dict at: 'type').
+	(dict includesKey: 'type')
+		ifTrue: [ 
+			type := references at: (dict at: 'type').
+		 ]
+		ifFalse: [
+			"This enumeration does not reference an existing integer type. Synthesize a suitable one."
+			type := DWARFBaseType new from:
+				{
+					'name' -> '(enum auto type)'.
+					'byte_size' -> (dict at: 'byte_size' ifAbsent: 4).
+					'encoding' -> '(signed)'.
+				} asDictionary. ].
 	enumerators :=
 		dict values
 			select: #isDictionary

--- a/frontend/Studio-Extension/StudioDAGLayout.class.st
+++ b/frontend/Studio-Extension/StudioDAGLayout.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #StudioDAGLayout,
+	#superclass : #RTSugiyamaLayout,
+	#category : #'Studio-Extension'
+}
+
+{ #category : #private }
+StudioDAGLayout >> buildLayers: g [
+	
+	| w layerNr u vertices vertex layer done layersTmp layerNrsTmp |
+	w := self maxFloat.
+	u := OrderedCollection new.
+	layers := IdentityDictionary new.
+	layerNrs := IdentityDictionary new.	"Assign all nodes to layers"
+	[g isEmpty]
+		whileFalse:
+			[vertices := g
+				select:
+					[:e | (self parentsFor: e) allSatisfy: [:node | u includes: node]].
+			vertex := vertices detectMax: [:e | labels at: e].
+			done := false.
+			layerNr := 1.
+			[done]
+				whileFalse:
+					[layer := layers
+						at: layerNr
+						ifAbsentPut: [OrderedCollection new].
+					(layer size >= w
+						or:
+							[(self parentsFor: vertex) anySatisfy: [:n | (layerNrs at: n) >= layerNr]])
+						ifTrue: [layerNr := layerNr + 1]
+						ifFalse: [done := true]].
+			layer add: vertex.
+			layerNrs at: vertex put: layerNr.
+			u add: vertex.
+			g remove: vertex].
+	layerNr := layers keys max.
+	layersTmp := layers.
+	layers := IdentityDictionary new.
+	layerNrsTmp := layerNrs.
+	layersTmp keysAndValuesDo: [ :k :v | layers at: layerNr - k + 1 put: v ].
+	layerNrsTmp keysAndValuesDo: [ :k :v | layerNrs at: k put: layerNr - v + 1 ].
+
+]

--- a/frontend/Studio-RaptorJIT/Collection.extension.st
+++ b/frontend/Studio-RaptorJIT/Collection.extension.st
@@ -9,6 +9,7 @@ Collection >> irListViewIn: composite title: aTitle [
 		column: 'Num' evaluated: #irRefString width: 40;
 		column: 'Loc' evaluated: #irRegisterString width: 40;
 		column: 'Flags' evaluated: #irFlagsString width: 40;
+		column: 'Type' evaluated: #typename width: 40;
 		column: 'Opcode' evaluated: #opcode width: 50;
 		column: 'Operands' evaluated: #operandsString width: 1000;
 		addAction: [

--- a/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
@@ -121,11 +121,12 @@ RJITAuditLog >> loadFromFileNamed: fileName [
 		stream := ReadStream on: log.
 		mp := MpDecoder on: stream.
 		count := 1.
-		[  mp atEnd ] whileFalse: [
+		[ [  mp atEnd ] whileFalse: [
 			job title: 'Reading audit.log record #', count asString.
 			self addRecord: mp next.
 			count := count + 1.
 			job progress: stream position / log size. ]
+		] on: Error do: [ :e | UIManager default inform: 'Finishing at msgpack error: ', e asString ].
 	] asJob run.
 	UIManager default inform: 'Loaded ', events size asString, ' RaptorJIT events (auditlog)'.
 ]

--- a/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
@@ -19,6 +19,17 @@ RJITAuditLog class >> loadFromFileNamed: fileName withDWARF: dwarf [
 
 ]
 
+{ #category : #decoding }
+RJITAuditLog >> addBlob: dict [
+	(dict at: 'name') = 'lj_dwarf.dwo' ifTrue: [ 
+		self addDWARF: (dict at: 'data') ].
+]
+
+{ #category : #accessing }
+RJITAuditLog >> addDWARF: byteArray [
+	self dwarf: (DWARF new loadFromByteArray: byteArray)
+]
+
 { #category : #initialization }
 RJITAuditLog >> addEvent: dict [
 	| event |
@@ -47,6 +58,7 @@ RJITAuditLog >> addRecord: dict [
    type := dict at: 'type'.
    type = 'event' ifTrue:  [ self addEvent: dict ].
    type = 'memory' ifTrue: [ self addMemory: dict ].
+	type = 'blob' ifTrue: [ self addBlob: dict ].
 ]
 
 { #category : #visualization }

--- a/frontend/Studio-RaptorJIT/RJITDisassembler.class.st
+++ b/frontend/Studio-RaptorJIT/RJITDisassembler.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #RJITDisassembler,
+	#superclass : #Object,
+	#category : #'Studio-RaptorJIT'
+}
+
+{ #category : #'as yet unclassified' }
+RJITDisassembler class >> disassemble: byteArray [
+	^ self disassemble: byteArray address: 0
+]
+
+{ #category : #'as yet unclassified' }
+RJITDisassembler class >> disassemble: byteArray address: address [
+	| tmp proc |
+	tmp := FileReference newTempFilePrefix: 'mcode' suffix: '.bin'.
+	tmp writeStream binary nextPutAll: byteArray asByteArray; close.
+	proc := PipeableOSProcess command: 'disasm ', tmp fullName, ' 0x', (address radix: 16).
+	^ proc output.
+
+]

--- a/frontend/Studio-RaptorJIT/RJITFlashback.class.st
+++ b/frontend/Studio-RaptorJIT/RJITFlashback.class.st
@@ -58,7 +58,9 @@ RJITFlashback >> byteAt: byteAddress [
 
 { #category : #accessing }
 RJITFlashback >> bytesAt: anAddress size: size [
-	^ image getBytes: size atAddress: anAddress atTime: time.
+	^ size = 0
+		ifTrue: [ #[] ]
+		ifFalse: [ image getBytes: size atAddress: anAddress atTime: time ].
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -20,7 +20,8 @@ Class {
 		'mcode',
 		'szmcode',
 		'mcodeAddress',
-		'phiParent'
+		'phiParent',
+		'phiChild'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -146,6 +147,7 @@ RJITIRInstruction >> attributes [
 RJITIRInstruction >> baseShape [
 	| shape |
 	shape := RTBox new width: 50; height: 20; color: self roassalColor; borderColor: Color lightGray; borderWidth: 1.
+	szmcode = 0 ifTrue: [ shape borderStyle: #dash ].
 	self isSpilledOntoStack ifTrue: [ shape borderColor: Color black; borderWidth: 2 ].
 	^ shape
 
@@ -174,14 +176,14 @@ RJITIRInstruction >> gtInspectorIRInstructionIn: composite [
 
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorInputListingIn: composite [
-	<gtInspectorPresentationOrder: 2>
+	<gtInspectorPresentationOrder: 3>
 	self transitiveInputs irListViewIn: composite title: 'Input List'.
 
 ]
 
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorInputTreeIn: composite [
-	<gtInspectorPresentationOrder: 4>
+	<gtInspectorPresentationOrder: 6>
 	composite roassal2
 		title: 'Input Tree';
 		initializeView: [ trace irTreeViewOfInstructions: self transitiveInputs ].
@@ -189,15 +191,31 @@ RJITIRInstruction >> gtInspectorInputTreeIn: composite [
 ]
 
 { #category : #initialization }
+RJITIRInstruction >> gtInspectorRelatedListingIn: composite [
+	<gtInspectorPresentationOrder: 2>
+	self transitiveRelations irListViewIn: composite title: 'Related List'.
+
+]
+
+{ #category : #initialization }
+RJITIRInstruction >> gtInspectorRelatedTreeIn: composite [
+	<gtInspectorPresentationOrder: 5>
+	composite roassal2
+		title: 'Related Tree';
+		initializeView: [ trace irTreeViewOfInstructions: self transitiveRelations ].
+
+]
+
+{ #category : #initialization }
 RJITIRInstruction >> gtInspectorUsesListingIn: composite [
-	<gtInspectorPresentationOrder: 3>
+	<gtInspectorPresentationOrder: 4>
 	self transitiveUses irListViewIn: composite title: 'Uses List'.
 
 ]
 
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorUsesTreeIn: composite [
-	<gtInspectorPresentationOrder: 5>
+	<gtInspectorPresentationOrder: 7>
 	composite roassal2
 		title: 'Uses Tree';
 		initializeView: [ trace irTreeViewOfInstructions: self transitiveUses ].
@@ -304,11 +322,13 @@ RJITIRInstruction >> irString [
 			nextPutAll: ((self type = #nil ifTrue: [ '' ] ifFalse: [ self type ]) padRightTo: 6);
 			space;
 			nextPutAll: (opcode padRightTo: 6).
-		op1ins ifNotNil: [ s space; nextPutAll: (op1ins irRefString padRightTo: 5) ].
-		mode op1mode = #lit ifTrue: [ s space; nextPutAll: '#' , op1 printString ].
-		op2ins ifNotNil: [ s space; nextPutAll: (op2ins irRefString padRightTo: 5) ].
-		mode op2mode = #lit ifTrue: [ s space; nextPutAll: '#' , op2 printString ].
-		].
+		op1ins
+			ifNotNil: [ s space; nextPutAll: (op1ins irRefString padRightTo: 5) ]
+			ifNil: [ self op1InlineString ifNotNil: [ :str | s space; nextPutAll: str ] ].
+		op2ins
+			ifNotNil: [ s space; nextPutAll: (op2ins irRefString padRightTo: 5) ]
+			ifNil: [ self op2InlineString ifNotNil: [ :str | s space; nextPutAll: str ] ].
+	].
  
 ]
 
@@ -419,7 +439,9 @@ RJITIRInstruction >> link: aGCtrace [
 	mode op1mode = #ref ifTrue: [ op1ins := self resolveIR: op1 in: aGCtrace ].
 	mode op2mode = #ref ifTrue: [ op2ins := self resolveIR: op2 in: aGCtrace ].
 	opcode = 'phi' ifTrue: [ 
-		op1ins ifNotNil: #setPhiOperand.
+		op1ins ifNotNil: [
+			op1ins setPhiOperand.
+			op1ins phiChild: op2ins ].
 		op2ins ifNotNil: [
 			op2ins setPhiOperand.
 			op2ins phiParent: op1ins ] ].
@@ -471,10 +493,10 @@ RJITIRInstruction >> op2InlineString [
 		^ '#', op2 asString ].
 	(#(fload fref) includes: opcode) ifTrue: [
 		[ ^ (irIns dwarf valueToName: op2 inEnumerationWith: #IRFL__MAX) asIrFieldName ]
-		  on: NotFound do: [] ].
+		  on: Error do: [] ].
 	(#(calln calll calls) includes: opcode) ifTrue: [ 
 		[ ^ (irIns dwarf valueToName: op2 inEnumerationWith: #IRCALL__MAX) asIrCallName ]
-		  on: NotFound do: [] ].
+		  on: Error do: [] ].
 	#fpmath = opcode ifTrue: [ 
 		[ ^ (irIns dwarf valueToName: op2 inEnumerationWith: #IRFPM__MAX) asIrFloatOperationName ]
 		  on: NotFound do: [] ].
@@ -503,14 +525,15 @@ RJITIRInstruction >> opcode [
 RJITIRInstruction >> operand1String [
 	^ String streamContents: [ :s |
 		op1ins ifNotNil: [ s nextPutAll: (op1ins irRefString padRightTo: 5) ].
-		mode op1mode = #lit ifTrue: [ s space; nextPutAll: '#' , op1 printString ]. ]
+		self op1InlineString ifNotNil: [ :str | ^ s nextPutAll: str ] ]
+	
 ]
 
 { #category : #'as yet unclassified' }
 RJITIRInstruction >> operand2String [
 	^ String streamContents: [ :s |
 		op2ins ifNotNil: [ s nextPutAll: (op2ins irRefString padRightTo: 5) ].
-		mode op2mode = #lit ifTrue: [ s space; nextPutAll: '#' , op2 printString ]. ]
+		self op2InlineString ifNotNil: [ :str | ^ s nextPutAll: str ] ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -518,6 +541,16 @@ RJITIRInstruction >> operandsString [
 	opcode = #loop ifTrue: [ ^ '-----------------------------------------' ].
 	^ self operand1String , String space, self operand2String.
 
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> phiChild [
+	^ phiChild
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> phiChild: ins [
+	phiChild := ins
 ]
 
 { #category : #accessing }
@@ -638,6 +671,11 @@ RJITIRInstruction >> transitiveInputs [
 	^ trace transitiveInputsOf: self.
 ]
 
+{ #category : #accessing }
+RJITIRInstruction >> transitiveRelations [
+	^ self transitiveInputs union: self transitiveUses
+]
+
 { #category : #querying }
 RJITIRInstruction >> transitiveUses [
 	^ trace transitiveUsesOf: self.
@@ -645,5 +683,11 @@ RJITIRInstruction >> transitiveUses [
 
 { #category : #initialization }
 RJITIRInstruction >> type [
+	^ type
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> typename [
+	type = #pgc ifTrue: [ ^ 'obj' ].
 	^ type
 ]

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -19,7 +19,8 @@ Class {
 		'trace',
 		'mcode',
 		'szmcode',
-		'mcodeAddress'
+		'mcodeAddress',
+		'phiParent'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -146,7 +147,6 @@ RJITIRInstruction >> baseShape [
 	| shape |
 	shape := RTBox new width: 50; height: 20; color: self roassalColor; borderColor: Color lightGray; borderWidth: 1.
 	self isSpilledOntoStack ifTrue: [ shape borderColor: Color black; borderWidth: 2 ].
-	szmcode = 0 ifTrue: [ shape borderStyle: #dash ].
 	^ shape
 
 ]
@@ -262,8 +262,11 @@ RJITIRInstruction >> irRefString [
 				^ proto sourceName, ':', (proto bytecodeLine: 0) asString. ] on: RJITFlashbackDataMissing do: [] ] ].
 	opcode = #kint64 ifTrue: [
 		| v |
-		v := irIns flashback decodeTypeNamed: 'uint64_t' at: irIns address + 8.
-		^ v value asString, 'LL' ].
+		v := irIns flashback decodeTypeNamed: 'int64_t' at: irIns address + 8.
+		^ String streamContents: [ :s |
+			v value >= 0 ifTrue: [ s nextPut: $+ ].
+			s nextPutAll: v asString.
+			v value <= (2 raisedTo: 48) ifTrue: [ s nextPutAll: ' (0x', (v value radix: 16), ')' ] ] ].
 	opcode = #knull ifTrue: [ ^'NULL' ].
 	(#(kptr kkptr) includes: opcode) ifTrue: [
 		| v |
@@ -381,6 +384,12 @@ RJITIRInstruction >> isNop [
 ]
 
 { #category : #initialization }
+RJITIRInstruction >> isPhi [
+	^ opcode = #phi
+
+]
+
+{ #category : #initialization }
 RJITIRInstruction >> isSpilledOntoStack [
 	"Return true if the IR value is stored on the stack instead of in a register."
 	^ stackSlot > 0
@@ -411,7 +420,9 @@ RJITIRInstruction >> link: aGCtrace [
 	mode op2mode = #ref ifTrue: [ op2ins := self resolveIR: op2 in: aGCtrace ].
 	opcode = 'phi' ifTrue: [ 
 		op1ins ifNotNil: #setPhiOperand.
-		op2ins ifNotNil: #setPhiOperand. ]
+		op2ins ifNotNil: [
+			op2ins setPhiOperand.
+			op2ins phiParent: op1ins ] ].
 ]
 
 { #category : #accessing }
@@ -507,6 +518,16 @@ RJITIRInstruction >> operandsString [
 	opcode = #loop ifTrue: [ ^ '-----------------------------------------' ].
 	^ self operand1String , String space, self operand2String.
 
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> phiParent [
+	^ phiParent
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> phiParent: ins [
+	phiParent := ins
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -16,7 +16,10 @@ Class {
 		'index',
 		'isPhiOperand',
 		'mode',
-		'trace'
+		'trace',
+		'mcode',
+		'szmcode',
+		'mcodeAddress'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -143,6 +146,7 @@ RJITIRInstruction >> baseShape [
 	| shape |
 	shape := RTBox new width: 50; height: 20; color: self roassalColor; borderColor: Color lightGray; borderWidth: 1.
 	self isSpilledOntoStack ifTrue: [ shape borderColor: Color black; borderWidth: 2 ].
+	szmcode = 0 ifTrue: [ shape borderStyle: #dash ].
 	^ shape
 
 ]
@@ -150,6 +154,11 @@ RJITIRInstruction >> baseShape [
 { #category : #accessing }
 RJITIRInstruction >> constantValue [
 	self shouldBeImplemented.
+]
+
+{ #category : #initialization }
+RJITIRInstruction >> disassemble [
+	^ RJITDisassembler disassemble: mcode address: mcodeAddress.
 ]
 
 { #category : #initialization }
@@ -406,6 +415,16 @@ RJITIRInstruction >> link: aGCtrace [
 ]
 
 { #category : #accessing }
+RJITIRInstruction >> mcode: bytes [
+	mcode := bytes
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> mcodeAddress: address [
+	mcodeAddress := address
+]
+
+{ #category : #accessing }
 RJITIRInstruction >> op1 [
 	^ op1 ifNil: [ op12 ].
 ]
@@ -419,6 +438,8 @@ RJITIRInstruction >> op12 [
 RJITIRInstruction >> op1InlineString [
 	(#(cnew cnewi) includes: opcode) ifTrue: [
 		^ irIns flashback auditLog ctypeName: op1ins op12 ].
+	#sload = opcode ifTrue: [
+		^ '#' , op1 asString ].
 	(op1ins ~= nil and: [ op1ins isConstant]) ifTrue: [ ^ op1ins irRefString ].
 	^ nil
 ]
@@ -437,6 +458,22 @@ RJITIRInstruction >> op2 [
 RJITIRInstruction >> op2InlineString [
 	(#(urefo urefc) includes: opcode) ifTrue: [ 
 		^ '#', op2 asString ].
+	(#(fload fref) includes: opcode) ifTrue: [
+		[ ^ (irIns dwarf valueToName: op2 inEnumerationWith: #IRFL__MAX) asIrFieldName ]
+		  on: NotFound do: [] ].
+	(#(calln calll calls) includes: opcode) ifTrue: [ 
+		[ ^ (irIns dwarf valueToName: op2 inEnumerationWith: #IRCALL__MAX) asIrCallName ]
+		  on: NotFound do: [] ].
+	#fpmath = opcode ifTrue: [ 
+		[ ^ (irIns dwarf valueToName: op2 inEnumerationWith: #IRFPM__MAX) asIrFloatOperationName ]
+		  on: NotFound do: [] ].
+	#sload = opcode ifTrue: [ 
+		^ String streamContents: [ :s |
+			{ 1->$P. 2->$F. 4->$T. 8->$C. 16->$R. 32->$I. } do: [ :a |
+				(op2 bitAt: a key) = 1 ifTrue: [ s nextPut: a value ] ]
+			 ] ].
+	#xload = opcode ifTrue: [ 
+		^ (#(R V RV U RU VU RVU) at: op2+1) asString ].
 	(op2ins ~= nil and: [ op2ins isConstant ]) ifTrue: [ ^ op2ins irRefString ].
 	^ nil
 ]
@@ -476,7 +513,9 @@ RJITIRInstruction >> operandsString [
 RJITIRInstruction >> popupSummary [
 	^ (RJITIRInstruction opcodeSummaries at: opcode ifAbsent: [ '(unknown opcode)' ]) ,
 		Character cr asString,
-		self irString.
+		self irString,
+		Character cr asString, Character cr asString,
+		self disassemble.
 ]
 
 { #category : #initialization }
@@ -566,6 +605,11 @@ RJITIRInstruction >> shape [
 { #category : #initialization }
 RJITIRInstruction >> stackSlot [
 	^ stackSlot
+]
+
+{ #category : #accessing }
+RJITIRInstruction >> szmcode: size [
+	szmcode := size
 ]
 
 { #category : #querying }

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -38,7 +38,7 @@ RJITProcess >> fromPath: aPath [
 	auditPath := path / 'audit.log'.
 	[ dwarfPath isFile and: auditPath isFile ] assertWithDescription:
 		'JIT audit log not found'.
-	auditLog := RJITAuditLog loadFromFileNamed: auditPath pathString withDWARF: (DWARF loadFromFileNamed: dwarfPath pathString).
+	auditLog := RJITAuditLog new loadFromFileNamed: auditPath pathString.
 	auditLog process: self.
 	"Load VMProfile data with progress monitoring."
 	vmprofiles := OrderedCollection new.

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -50,6 +50,27 @@ RJITTrace >> children [
 	^ self process traces select: [ :tr | tr parent = self ]
 ]
 
+{ #category : #'instance creation' }
+RJITTrace >> decodeIrMcodeMapping [
+	| szirmcode mcodeAddr mcodeOffset flashback nbytes index |
+	flashback := gctrace flashback.
+	szirmcode := gctrace szirmcode asInteger.
+	mcodeAddr := gctrace mcode asInteger.
+	"First value is size of trace head (before first instruction)"
+	mcodeOffset := (flashback decodeTypeNamed: #uint16_t at: szirmcode) value.
+	index := 2.
+	self irInstructions do: [ :ins |
+		nbytes := (flashback decodeTypeNamed: #uint16_t at: szirmcode + index) value.
+		Transcript show: 'nbytes: ', nbytes asString; cr.
+		ins mcode: (flashback bytesAt: mcodeAddr + mcodeOffset size: nbytes).
+		ins szmcode: nbytes.
+		ins mcodeAddress: mcodeAddr + mcodeOffset.
+		index := index + 2. "next uint16_t"
+		mcodeOffset := mcodeOffset + nbytes.
+	].
+
+]
+
 { #category : #accessing }
 RJITTrace >> exitno [
 	^ exitno
@@ -81,6 +102,7 @@ RJITTrace >> from: aGCtrace withExistingTraces: traces [
 	link := traces detect: [ :tr | tr traceno = gctrace link ] ifNone: [ nil ].
 	linktype := (dwarf valueToName: gctrace linktype inEnumerationWith: 'LJ_TRLINK_NONE') asLinkTypeName.
 	start := gctrace startpc.
+
 ]
 
 { #category : #'gt-inspector-extension' }
@@ -197,6 +219,7 @@ RJITTrace >> irInstructions [
 	irInstructions isBlock ifTrue: [ 
 		irInstructions := irInstructions value.
 		irInstructions do: [ :ins | ins link: self. ].
+		self decodeIrMcodeMapping.
  		].
 	^ irInstructions.
 

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -163,7 +163,6 @@ RJITTrace >> gtInspectorInfoIn: composite [
 					format: #asString;
 					sorted: [ :x :y | x all > y all ];
 					column: 'Profile' evaluated: [ :pt | pt vmprofile name ].
-				"#( all vm mcode gc )"
 				#( interp c igc exit record opt asm head loop ffi jgc ) do: [ :key |
 					tab column: key asString evaluated: key width: 45 ].
 				].
@@ -277,8 +276,13 @@ RJITTrace >> irTreeViewOfInstructions: insns [
 		connectFrom: #op1ins;
 		shape: (RTLine new color: Color black trans; attachPoint: RJITOperand2AttachPoint new; yourself);
 		connectFrom: #op2ins.
-	RTDominanceTreeLayout new doNotAttachPoint; on: head.
-	RTDominanceTreeLayout new doNotAttachPoint; on: loop.
+	RTEdgeBuilder new
+		view: view;
+		objects: (self irInstructions);
+		shape: (RTLine new width: 5; color: Color red"; attachPoint: RTVerticalAttachPoint");
+		connectFrom: #phiParent.
+	StudioDAGLayout new doNotAttachPoint; horizontalGap: 30; on: head.
+	StudioDAGLayout new doNotAttachPoint; horizontalGap: 30; on: loop.
 	loopInsns size > 0 ifTrue: [
 		view add: separator.
 		RTVerticalLineLayout on: { head. separator. loop }. ].

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -276,13 +276,13 @@ RJITTrace >> irTreeViewOfInstructions: insns [
 		connectFrom: #op1ins;
 		shape: (RTLine new color: Color black trans; attachPoint: RJITOperand2AttachPoint new; yourself);
 		connectFrom: #op2ins.
+	RTTreeLayout new doNotAttachPoint; on: head.
+	RTTreeLayout new doNotAttachPoint; on: loop.
 	RTEdgeBuilder new
 		view: view;
 		objects: (self irInstructions);
 		shape: (RTArrowedLine new color: (Color red alpha: 0.5); attachPoint: RTBorderAttachPoint new);
 		connectFrom: #phiChild.
-	RTTreeLayout on: head.
-	RTTreeLayout on: loop.
 	loopInsns size > 0 ifTrue: [
 		view add: separator.
 		RTVerticalLineLayout on: { head. separator. loop }. ].

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -254,9 +254,9 @@ RJITTrace >> irTreeViewOfInstructions: insns [
 		loopInsns := { }.
 	 ].
 	head := RTGroup new addAll: (headInsns collect: #asElement); yourself.
-	loop := RTGroup new addAll: (loopInsns collect: #asElement); yourself.
+	loop := RTGroup new addAll: (loopInsns reject: #isPhi thenCollect: #asElement); yourself.
 	all := RTGroup new addAll: head; addAll: loop; yourself.
-	separator := RTLabel new elementOn: #'LOOP:'.
+	separator := RTLabel new color: Color black; height: 18; elementOn: #'LOOP:'.
 	view := RTView new.
 	view addAll: all; addAll: loop.
 	
@@ -279,8 +279,8 @@ RJITTrace >> irTreeViewOfInstructions: insns [
 	RTEdgeBuilder new
 		view: view;
 		objects: (self irInstructions);
-		shape: (RTLine new width: 5; color: Color red"; attachPoint: RTVerticalAttachPoint");
-		connectFrom: #phiParent.
+		shape: (RTArrowedLine new color: (Color red alpha: 0.5); attachPoint: RTBorderAttachPoint new);
+		connectFrom: #phiChild.
 	StudioDAGLayout new doNotAttachPoint; horizontalGap: 30; on: head.
 	StudioDAGLayout new doNotAttachPoint; horizontalGap: 30; on: loop.
 	loopInsns size > 0 ifTrue: [

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -35,7 +35,7 @@ RJITTrace >> asElement [
 	| box |
 	box := RTBox new size: [ :tr | tr numberOfIrInstructions sqrt * 5 ];
 					borderColor: Color black;
-					color: [ :tr | Color red alpha: ((self totalSamples) / self process totalSamples) ].
+					color: [ :tr | Color red alpha: ((self totalSamples) / (Float fmin + self process totalSamples)) ].
 	self isRootTrace ifTrue: [ box borderColor: Color black; borderWidth: 2 ].
 	^ box	+ (RTLabel new color: Color black; text: #traceno) elementOn: self.	
 ]
@@ -200,7 +200,7 @@ RJITTrace >> info [
 		'IR Instructions' -> self numberOfIrInstructions.
 		'Profiler samples' -> ('{1} ({2}%)' format: {
 			self totalSamples.
-			(self totalSamples * 100.0 / self process totalSamples) printShowingDecimalPlaces: 1.
+			(self totalSamples * 100.0 / (Float fmin + self process totalSamples)) printShowingDecimalPlaces: 1.
 		}).
 	}
 ]
@@ -281,8 +281,8 @@ RJITTrace >> irTreeViewOfInstructions: insns [
 		objects: (self irInstructions);
 		shape: (RTArrowedLine new color: (Color red alpha: 0.5); attachPoint: RTBorderAttachPoint new);
 		connectFrom: #phiChild.
-	StudioDAGLayout new doNotAttachPoint; horizontalGap: 30; on: head.
-	StudioDAGLayout new doNotAttachPoint; horizontalGap: 30; on: loop.
+	RTTreeLayout on: head.
+	RTTreeLayout on: loop.
 	loopInsns size > 0 ifTrue: [
 		view add: separator.
 		RTVerticalLineLayout on: { head. separator. loop }. ].

--- a/frontend/Studio-RaptorJIT/String.extension.st
+++ b/frontend/Studio-RaptorJIT/String.extension.st
@@ -19,6 +19,24 @@ String >> asIRInstructionType [
 ]
 
 { #category : #'*Studio-RaptorJIT' }
+String >> asIrCallName [
+	^ ((self withoutPrefix: #IRCALL_) asLowercase withoutPrefix: #lj_) replaceAll: $_ with: $.
+
+]
+
+{ #category : #'*Studio-RaptorJIT' }
+String >> asIrFieldName [
+	^ (self withoutPrefix: #IRFL_) asLowercase replaceAll: $_ with: $.
+
+]
+
+{ #category : #'*Studio-RaptorJIT' }
+String >> asIrFloatOperationName [
+	^ (self withoutPrefix: 'IRFPM_') asLowercase.
+
+]
+
+{ #category : #'*Studio-RaptorJIT' }
 String >> asLinkTypeName [
 	^ (self withoutPrefix: 'LJ_TRLINK_') asLowercase asSymbol.
 

--- a/overlays.nix
+++ b/overlays.nix
@@ -12,6 +12,7 @@
       timeliner = super.callPackage ./backend/timeliner {};
       vmprofiler = super.callPackage ./backend/vmprofiler {};
       dwarfish = super.callPackage ./backend/dwarfish {};
+      disasm = super.callPackage ./backend/disasm {};
     })
 ]
 


### PR DESCRIPTION
Quite a nice update on this branch!

IR instructions are disassembled with mouseover tooltip.

IR instructions that don't generate machine code have dashed borders.

Graph layout switches to Sugiyama (Graphviz) algorithm. This provides the important invariant that each node is placed as high as possible except that it must be below its parents. So the height of each node tells you the maximum dependency chain length through its ancestors. (So tall graphs are quite serial and wide graphs are quite parallel.)

Operands for IR instructions are decoded better especially for `SLOAD` and `FLOAD` and `CALLS`.

PHI instructions are now represented as red arrows. These show how values are updated from one iteration of a loop to the next. The arrow shows where a new value overwrites an old value at the end of a loop iteration i.e. how values are threaded from one iteration of a loop to the next.

DWARF debug information can be read from the `audit.log` file. This overrides the default that is bundled with Studio. This is important for forwards-compatibility to future modified RaptorJIT VMs.