### PR TITLE
Nix backend updates

### DIFF
--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -23,8 +23,8 @@ rec {
     src = fetchFromGitHub {
       owner = "lukego";
       repo = "raptorjit";
-      rev = "a5222e7a1e720807052125f545974da913a80db8";
-      sha256 = "0kh13x25hclcd699689cr156qicww4cscmcm99qga8shhx5q9acv";
+      rev = "92955dc8387c4980ebbc0656347fcc74d7ac2f04";
+      sha256 = "02jljk5nvgkqlz24cg98lipz2k2vxzlahch9a9fg93r3bi18pi9c";
     };
     installPhase = ''
       install -D src/raptorjit $out/bin/raptorjit

--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -20,11 +20,12 @@ rec {
   raptorjit = llvmPackages_4.stdenv.mkDerivation {
     name = "raptorjit-auditlog";
     nativeBuildInputs = [ gcc luajit ];
-    src = fetchFromGitHub {
+    src = /home/luke/git/raptorjit;
+    srcx = fetchFromGitHub {
       owner = "lukego";
       repo = "raptorjit";
-      rev = "840643881d676459f1c1d77dbd41600b682f8d56";
-      sha256 = "0mhs89kxf45jjy6rwkjblq22jjg9phficlmr7l8rfdx70k4mass4";
+      rev = "a5222e7a1e720807052125f545974da913a80db8";
+      sha256 = "0kh13x25hclcd699689cr156qicww4cscmcm99qga8shhx5q9acv";
     };
     installPhase = ''
       install -D src/raptorjit $out/bin/raptorjit

--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -76,7 +76,7 @@ rec {
       product = inspect raw;
     };
   # Convenience wrappers
-  run = luaSource: runCode (writeScript "script.lua" luaSource);
+  run = luaSource: runCode (writeTextDir "script.lua" luaSource);
   runTarball = url: runCode (fetchTarball url);
   runFile = runCode;
   runDirectory = runCode;

--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -17,7 +17,7 @@
 with pkgs; with builtins; with stdenv;
 
 rec {
-  raptorjit = llvmPackages_4.stdenv.mkDerivation {
+  raptorjit = stdenv.mkDerivation {
     name = "raptorjit-auditlog";
     nativeBuildInputs = [ gcc luajit ];
     src = fetchFromGitHub {

--- a/backend/raptorjit/default.nix
+++ b/backend/raptorjit/default.nix
@@ -20,8 +20,7 @@ rec {
   raptorjit = llvmPackages_4.stdenv.mkDerivation {
     name = "raptorjit-auditlog";
     nativeBuildInputs = [ gcc luajit ];
-    src = /home/luke/git/raptorjit;
-    srcx = fetchFromGitHub {
+    src = fetchFromGitHub {
       owner = "lukego";
       repo = "raptorjit";
       rev = "a5222e7a1e720807052125f545974da913a80db8";

--- a/bin/studio
+++ b/bin/studio
@@ -37,7 +37,7 @@ runstudio() {
   cmd="$2"
   export TMPDIR=$(mktemp -d)
   trap "rm -rf $TMPDIR" EXIT
-  nix-shell $nixopts --run "$cmd" -E - <<EOF
+  nix-shell $nixopts --run "STUDIO_PATH=$studio $cmd" -E - <<EOF
     with import $studio;
     runCommandNoCC "studio" {
       nativeBuildInputs = [ nixUnstable xorg.xauth perl $attr ];


### PR DESCRIPTION
Update to latest RaptorJIT (lukego/auditlog branch) and fix `bin/studio` to always use Nix definitions from the working tree (so that edits take effect immediately.)