### PR TITLE
RaptorJIT: Simplify code by assuming that DWARF data is in audit.log

### DIFF
--- a/backend/snabb/default.nix
+++ b/backend/snabb/default.nix
@@ -13,7 +13,6 @@ rec {
     [ -f $dir/audit.log ] || (echo "error: ./audit.log not found" >&2; exit 1)
     cp --no-preserve=mode -r $dir $out
     cd $out
-    cp ${./raptorjit-dwarf.json} raptorjit-dwarf.json
   '';
   processTarball = url: processDirectory (fetchTarball url);
 

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -36,7 +36,7 @@ RJITProcess >> fromPath: aPath [
 	path := aPath.
 	dwarfPath := path / 'raptorjit-dwarf.json'.
 	auditPath := path / 'audit.log'.
-	[ dwarfPath isFile and: auditPath isFile ] assertWithDescription:
+	[ auditPath isFile ] assertWithDescription:
 		'JIT audit log not found'.
 	auditLog := RJITAuditLog new loadFromFileNamed: auditPath pathString.
 	auditLog process: self.
@@ -148,12 +148,14 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 
 { #category : #accessing }
 RJITProcess >> totalSamples [
+	vmprofiles isEmpty ifTrue: [ ^0 ].
 	^ vmprofiles sum: #total
 
 ]
 
 { #category : #accessing }
-RJITProcess >> totalSamplesFor: trace [ 
+RJITProcess >> totalSamplesFor: trace [
+	vmprofiles ifEmpty: [ ^0 ]. 
 	^ vmprofiles sum: [ :p | (p trace: trace) all]
 ]
 


### PR DESCRIPTION
Studio had included some complicated Nix code for trying to obtain
suitable DWARF debug data for the virtual machine being inspected.
This is not needed with recent versions of RaptorJIT because the DWARF
data is included inline in the log file and can be extracted from
there.

Simple fixes also for loading an audit.log in isolation without
profiler data.