### PR TITLE
Frontend improvements for RaptorJIT

### DIFF
--- a/frontend/Studio-RaptorJIT/RJITBytecode.class.st
+++ b/frontend/Studio-RaptorJIT/RJITBytecode.class.st
@@ -72,3 +72,10 @@ RJITBytecode >> sourceLine [
 		ifCurtailed: [ ^'?' ].
 
 ]
+
+{ #category : #initialization }
+RJITBytecode >> sourceName [
+	prototype ifNil: [ ^ '' ].
+	^ prototype sourceName.
+
+]

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -124,6 +124,9 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 					sorted: [ :x :y | x samples > y samples ];
 					column: 'Location' evaluated: #location width: 240;
 					column: 'Samples' evaluated: #samples width: 60;
+					column: 'Mcode' evaluated: (percent value: #mcodePercent) width: w;
+					column: 'VM' evaluated: (percent value: #vmPercent) width: w;
+					column: 'GC' evaluated: (percent value: #gcPercent) width: w;
 					column: '#Root' evaluated: #numberOfRootTraces width: w;
 					column: '#Side' evaluated: #numberOfSideTraces width: w. ].
 			t transmit from: #locations; to: #traces; andShow: [ :a |

--- a/frontend/Studio-RaptorJIT/RJITRootTraceSet.class.st
+++ b/frontend/Studio-RaptorJIT/RJITRootTraceSet.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : #accessing }
+RJITRootTraceSet >> gcPercent [
+	^ self percentOf: #gc.
+]
+
+{ #category : #accessing }
 RJITRootTraceSet >> location [
 	| root |
 	root := traces detect: #isRootTrace ifNone: [ ^'?' ].
@@ -23,6 +28,12 @@ RJITRootTraceSet >> location: aLocation [
 ]
 
 { #category : #accessing }
+RJITRootTraceSet >> mcodePercent [
+	^ self percentOf: #mcode.
+
+]
+
+{ #category : #accessing }
 RJITRootTraceSet >> numberOfRootTraces [
 	^ traces count: #isRootTrace.
 
@@ -32,6 +43,19 @@ RJITRootTraceSet >> numberOfRootTraces [
 RJITRootTraceSet >> numberOfSideTraces [
 	^ traces count: #isSideTrace.
 
+]
+
+{ #category : #accessing }
+RJITRootTraceSet >> percentOf: aSelector [ 
+	| total acc |
+	total := 0.
+	acc := 0.
+	traces do: [ :tr |
+		| p |
+		p := profile trace: tr.
+		total := total + p all.
+		acc := acc + (p perform: aSelector). ].
+	^ acc * 100.0 / (total + Float fmin).
 ]
 
 { #category : #accessing }
@@ -69,4 +93,9 @@ RJITRootTraceSet >> traces [
 { #category : #accessing }
 RJITRootTraceSet >> traces: aCollection [ 
 	traces := aCollection
+]
+
+{ #category : #accessing }
+RJITRootTraceSet >> vmPercent [
+	^ self percentOf: #vm.
 ]

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -105,6 +105,21 @@ RJITTrace >> from: aGCtrace withExistingTraces: traces [
 
 ]
 
+{ #category : #accessing }
+RJITTrace >> functionContour [
+	| curdepth |
+	^ String streamContents: [ :s |
+		jitState bytecodes select: [ :bc | bc opcode isNotNil ] thenDo: [ :bc |
+			curdepth ~= bc framedepth ifTrue: [
+				curdepth := bc framedepth.
+				s
+					nextPutAll: ('*' repeat: bc framedepth + 1);
+					nextPutAll: ' ';
+					nextPutAll: bc sourceLine;
+					nextPut: Character cr.
+				 ] ] ].
+]
+
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorBytecodesIn: composite [
 	<gtInspectorPresentationOrder: 2>
@@ -147,7 +162,7 @@ RJITTrace >> gtInspectorInfoIn: composite [
 	composite tabulator
 		title: 'Info';
 		with: [ :t |
-			t row: #info; row: #profile.
+			t row: #info; row: #contour.
 			t transmit to: #info; andShow: [ :a |
 				a fastTable
 					title: 'Trace Attributes';
@@ -155,18 +170,11 @@ RJITTrace >> gtInspectorInfoIn: composite [
 					column: 'Name' evaluated: #key width: 100;
 					column: 'Value' evaluated: #value width: 600.
 				].
-			t transmit to: #profile; andShow: [ :a |
-				| tab |
-				tab := a fastTable 
-					title: 'Profiler Samples';
-					display: [ self process vmprofiles collect: [ :p | p trace: self ] ];
-					format: #asString;
-					sorted: [ :x :y | x all > y all ];
-					column: 'Profile' evaluated: [ :pt | pt vmprofile name ].
-				#( interp c igc exit record opt asm head loop ffi jgc ) do: [ :key |
-					tab column: key asString evaluated: key width: 45 ].
+			t transmit to: #contour; andShow: [ :a |
+				a text
+					title: 'Call Stack Contour';
+					display: [ self functionContour ] ]
 				].
-	].
 ]
 
 { #category : #'gt-inspector-extension' }
@@ -175,6 +183,22 @@ RJITTrace >> gtInspectorJITIn: composite [
 	composite fastList 
 		title: 'JIT';
 		display: [ self jitEvents ].
+
+]
+
+{ #category : #accessing }
+RJITTrace >> gtInspectorProfileIn: composite [
+	<gtInspectorPresentationOrder: 6>
+	| tab |
+	tab := composite fastTable 
+		title: 'Profile';
+		display: [ self process vmprofiles collect: [ :p | p trace: self ] ];
+		format: #asString;
+			sorted: [ :x :y | x all > y all ];
+			column: 'Profile' evaluated: [ :pt | pt vmprofile name ].
+	#( interp c igc exit record opt asm head loop ffi jgc ) do: [ :key |
+		tab column: key asString evaluated: key width: 45 ].
+
 
 ]
 


### PR DESCRIPTION
Add a "Call Stack Contour" summary to the trace (Info) tab. This shows only where function calls were entered or exited. It's like a brief summary of the recorded bytecodes log to show which code the trace is covering.

Show VM/MCode/GC percentage summaries for root trace sets (resolves #87.)

![screen shot 2018-05-03 at 15 21 20](https://user-images.githubusercontent.com/13791/39579240-8457e0e2-4ee6-11e8-9e00-aa3dddef4d75.png)

![screen shot 2018-05-03 at 15 21 49](https://user-images.githubusercontent.com/13791/39579239-84360d6e-4ee6-11e8-867c-2c1c6ef97202.png)
