### PR TITLE
Frontend: Add support for RaptorJIT declname

### DIFF
--- a/frontend/Studio-RaptorJIT/RJITBytecode.class.st
+++ b/frontend/Studio-RaptorJIT/RJITBytecode.class.st
@@ -67,9 +67,13 @@ RJITBytecode >> opcodeName [
 
 { #category : #initialization }
 RJITBytecode >> sourceLine [
-	prototype ifNil: [ ^ '' ].
-	^ [ prototype sourceName , ':' , (prototype bytecodeLine: position) asString ]
-		ifCurtailed: [ ^'?' ].
+	^ prototype ifNil: [ '?' ] ifNotNil: [ prototype sourceLine: position ]
+
+]
+
+{ #category : #accessing }
+RJITBytecode >> sourceLineShort [
+	^ prototype sourceLineShort: position
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITEvent.class.st
+++ b/frontend/Studio-RaptorJIT/RJITEvent.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #accessing }
 RJITEvent >> endSourceLine [
 	self numberOfBytecodes = 0 ifTrue: [ ^'?' ].
-	^ self jitState bytecodes last sourceLine.
+	^ self jitState bytecodes ifEmpty: [ '?' ] ifNotEmpty: [ :bc | bc last sourceLine ].
 ]
 
 { #category : #accessing }

--- a/frontend/Studio-RaptorJIT/RJITFlashback.class.st
+++ b/frontend/Studio-RaptorJIT/RJITFlashback.class.st
@@ -87,8 +87,10 @@ RJITFlashback >> decodeArrayOfTypeNamed: typename at: anAddress elements: elems 
 
 { #category : #accessing }
 RJITFlashback >> decodeCStringAt: anAddress [
-	^ (self decodeStringAt: anAddress size: 1024) copyUpTo: 0 asCharacter.
-
+	| size |
+	size := 0.
+	[ (self byteAt: anAddress + size) = 0 ] whileFalse: [ size := size + 1 ].
+	^ self decodeStringAt: anAddress size: size.
 ]
 
 { #category : #decoding }

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -166,11 +166,19 @@ RJITIRInstruction >> disassemble [
 { #category : #initialization }
 RJITIRInstruction >> gtInspectorIRInstructionIn: composite [
 	<gtInspectorPresentationOrder: 1>
-	composite table
+	composite tabulator
 		title: 'Info';
-		display: [ self attributes ];
-		column: 'Key' evaluated: #key width: 100;
-		column: 'Value' evaluated: #value.
+		with: [ :t |
+			t row: #element; row: #details.
+			t transmit to: #element; andShow: [ :a |
+				a roassal2
+					title: 'Instruction View';
+					initializeView: [ RTView new add: self asElement ] ].
+			t transmit to: #details; andShow: [ :a |
+				a text
+					title: 'Details';
+					display: [ self popupSummary ] ].
+		]
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -187,7 +187,7 @@ RJITProcess >> traceMapView [
 		edges := RTEdgeBuilder new
 						view: group;
 						objects: traces;
-						shape: (RTLine new);
+						shape: (RTLine new color: Color black);
 						connectToAll: #children.
 		RTHorizontalTreeLayout on: elements edges: edges.
 		].

--- a/frontend/Studio-RaptorJIT/RJITPrototype.class.st
+++ b/frontend/Studio-RaptorJIT/RJITPrototype.class.st
@@ -31,6 +31,19 @@ RJITPrototype >> bytecodeValues [
 
 ]
 
+{ #category : #accessing }
+RJITPrototype >> declname [
+	| ptr |
+	ptr := (gcproto child: #declname) value.
+	^ (ptr = nil or: [ ptr = 0 ]) ifTrue: [ nil ] ifFalse: [ ^ gcproto flashback decodeCStringAt: ptr ].
+
+]
+
+{ #category : #accessing }
+RJITPrototype >> firstLine [
+	^ firstline
+]
+
 { #category : #'instance creation' }
 RJITPrototype >> from: aGCproto [
 	gcproto := aGCproto.
@@ -57,9 +70,72 @@ RJITPrototype >> programCounterLine: pc [
 
 ]
 
+{ #category : #initialization }
+RJITPrototype >> sourceLine [
+	^ self sourceLine: 0
+]
+
+{ #category : #'as yet unclassified' }
+RJITPrototype >> sourceLine: position [
+	^ self sourceName: (self bytecodeLine: position).
+
+]
+
+{ #category : #initialization }
+RJITPrototype >> sourceLineShort [
+	^ self sourceLineShort: 0
+
+]
+
+{ #category : #'as yet unclassified' }
+RJITPrototype >> sourceLineShort: position [
+	^ self sourceName: (self bytecodeLine: position) long: false.
+
+]
+
 { #category : #accessing }
 RJITPrototype >> sourceName [
 	^ sourceName trimLeft: [ :x | x = $@ or: x = $= ]
+]
+
+{ #category : #accessing }
+RJITPrototype >> sourceName: line [
+	^ self sourceName: line long: true.
+]
+
+{ #category : #accessing }
+RJITPrototype >> sourceName: line long: isLong [
+	[
+		| chunk declname functionLine |
+		chunk := self sourceName.
+		declname := self declname.
+		functionLine := line - self firstLine + 1.
+		declname
+			ifNil: [ "limited debug information available (older RaptorJIT)"
+				^ sourceName, ':', line asString ]
+			ifNotNil: [ 
+				declname ifEmpty: [ declname := '<anonymous>' ].
+				^ isLong ifTrue: [
+					'({1}){2}:{3} ({4}:{5})' format:
+						{ chunk luaModuleName. declname. functionLine. chunk. line. } ]
+					ifFalse: [ 
+					'({1}){2}:{3}' format:
+						{ chunk luaModuleName. declname. functionLine.} ]
+						 ]
+	] value. "ifCurtailed: [ ^ '?' ]."
+
+]
+
+{ #category : #'as yet unclassified' }
+RJITPrototype >> sourcePC: programCounter [
+	^ self sourceName: (self programCounterLine: programCounter).
+
+]
+
+{ #category : #'as yet unclassified' }
+RJITPrototype >> sourcePCShort: programCounter [
+	^ self sourceName: (self programCounterLine: programCounter) long: false.
+
 ]
 
 { #category : #'as yet unclassified' }

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -30,19 +30,31 @@ RJITTrace >> allChildren [
 
 ]
 
-{ #category : #'gt-inspector-extension' }
-RJITTrace >> asElement [
-	| box |
-	box := RTBox new size: [ :tr | tr numberOfHeadIrInstructions sqrt * 5 ];
-					borderColor: Color black;
-					color: [ :tr | Color red alpha: ((self totalSamples) / (Float fmin + self process totalSamples)) ].
-	self isRootTrace ifTrue: [ box borderColor: Color black; borderWidth: 2 ].
-	^ box	+ (RTLabel new color: Color black; text: #traceno) elementOn: self.	
+{ #category : #accessing }
+RJITTrace >> ancestorFunctionContour [
+	parent ifNil: [ ^ '' ] ifNotNil: [ 
+		^ parent ancestorFunctionContour ,
+			'Parent trace ', parent traceno asString, String cr, 
+			parent functionContour, String cr. ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> asElement [
+	| base |
+	base := self hasLoop ifTrue: [ RTEllipse new ] ifFalse: [ RTBox new ].
+	base size: [ :tr |
+		| area |
+		area := tr numberOfHeadIrInstructions * 10.
+		self hasLoop ifTrue: [ 2 * (area / Float pi) sqrt ] ifFalse: [ area sqrt ]].
+	base borderColor: Color black;
+			color: [ :tr | Color red alpha: ((self totalSamples) / (Float fmin + self process totalSamples)) ].
+	self isRootTrace ifTrue: [ base borderColor: Color black; borderWidth: 2 ].
+	^ base	+ (RTLabel new color: Color black; text: #traceno) elementOn: self.	
+]
+
+{ #category : #initialization }
 RJITTrace >> bytecodes [
-	self shouldBeImplemented.
+	^ jitState bytecodes
 ]
 
 { #category : #accessing }
@@ -113,7 +125,7 @@ RJITTrace >> functionContour [
 			curdepth ~= bc framedepth ifTrue: [
 				curdepth := bc framedepth.
 				s
-					nextPutAll: ('*' repeat: bc framedepth + 1);
+					nextPutAll: ('    ' repeat: bc framedepth + 1);
 					nextPutAll: ' ';
 					nextPutAll: bc sourceLine;
 					nextPut: Character cr.
@@ -125,6 +137,15 @@ RJITTrace >> gtInspectorBytecodesIn: composite [
 	<gtInspectorPresentationOrder: 2>
 	jitState ifNil: [ ^nil ].
 	jitState gtInspectorBytecodesIn: composite.
+
+]
+
+{ #category : #accessing }
+RJITTrace >> gtInspectorContourIn: composite [
+	<gtInspectorPresentationOrder: 2>
+	composite text
+		title: 'Contour';
+		display: [ self ownFunctionContour ].
 
 ]
 
@@ -156,27 +177,6 @@ RJITTrace >> gtInspectorIRTreeIn: composite [
 
 ]
 
-{ #category : #accessing }
-RJITTrace >> gtInspectorInfoIn: composite [
-	<gtInspectorPresentationOrder: 1>
-	composite tabulator
-		title: 'Info';
-		with: [ :t |
-			t row: #info; row: #contour.
-			t transmit to: #info; andShow: [ :a |
-				a fastTable
-					title: 'Trace Attributes';
-					display: [ self info ];
-					column: 'Name' evaluated: #key width: 100;
-					column: 'Value' evaluated: #value width: 600.
-				].
-			t transmit to: #contour; andShow: [ :a |
-				a text
-					title: 'Call Stack Contour';
-					display: [ self functionContour ] ]
-				].
-]
-
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtInspectorJITIn: composite [
 	<gtInspectorPresentationOrder: 5>
@@ -202,6 +202,18 @@ RJITTrace >> gtInspectorProfileIn: composite [
 
 ]
 
+{ #category : #accessing }
+RJITTrace >> gtInspectorSummaryIn: composite [
+	<gtInspectorPresentationOrder: 1>
+	composite fastTable
+		title: 'Summary';
+		display: [ self info ];
+		selectionTransformation: #value;
+		column: 'Name' evaluated: #key width: 100;
+		column: 'Value' evaluated: #value width: 600.
+
+]
+
 { #category : #initializing }
 RJITTrace >> hasLoop [
 	^ self loop notNil.
@@ -215,13 +227,14 @@ RJITTrace >> headInstructions [
 { #category : #accessing }
 RJITTrace >> info [
 	^{
-		'Summary' -> self printString.
-		'TraceNo' -> traceno.
-		'Root' -> (root = self ifTrue: [ '(self)' ] ifFalse: [ root ]).
-		'Parent' -> parent.
-		'Link' -> (link ifNil: linktype).
-		'Start Line' -> self startLine.
-		'IR Instructions' -> self numberOfIrInstructions.
+		'Self' -> self.
+		'Parent' -> (parent ifNil: ['-']).
+		'Link' -> (link ifNil: [ self linkname ]).
+		'Root' -> (root = self ifTrue: [ '(self)' ] ifFalse: [ root = parent ifTrue: [ '(parent)' ] ifFalse: [ root ] ]).
+		'---' -> '---'.
+		'Parent Exit' -> (parent ifNil: [ '-' ] ifNotNil: [ exitno ]).
+		'# Bytecode insns' -> self bytecodes size.
+		'# IR insns' -> self numberOfIrInstructions.
 		'Profiler samples' -> ('{1} ({2}%)' format: {
 			self totalSamples.
 			(self totalSamples * 100.0 / (Float fmin + self process totalSamples)) printShowingDecimalPlaces: 1.
@@ -302,7 +315,7 @@ RJITTrace >> irTreeViewOfInstructions: insns [
 		connectFrom: #op2ins.
 	layoutEdges := RTElement edgesForLongTree: all.
 	RTTreeLayout new doNotAttachPoint; userDefinedEdges: layoutEdges; on: head.
-	RTTreeLayout new doNotAttachPoint; on: loop.
+	RTTreeLayout new doNotAttachPoint; "userDefinedEdges: layoutEdges;" on: loop.
 	RTEdgeBuilder new
 		view: view;
 		objects: (self irInstructions);
@@ -377,6 +390,12 @@ RJITTrace >> numberOfIrInstructions [
 ]
 
 { #category : #accessing }
+RJITTrace >> ownFunctionContour [
+	^ 'Trace ', self traceno asString, String cr, self functionContour.
+
+]
+
+{ #category : #accessing }
 RJITTrace >> parent [
 	^parent
 ]
@@ -390,8 +409,16 @@ RJITTrace >> parentname [
 RJITTrace >> printOn: aStream [
 	aStream nextPutAll: 'trace '.
 	aStream nextPutAll: traceno asString.
-	self isSideTrace ifTrue: [ aStream nextPutAll: '/' , self parentname ].
-	aStream nextPutAll: ' from ', self startLine.
+	"self isSideTrace ifTrue: [ aStream nextPutAll: ' (' , self parentname, ')' ]."
+	aStream nextPutAll: (self hasLoop ifTrue: [ ' loop at ' ] ifFalse: [ ' patch from ' ]).
+	aStream nextPutAll: self startLineShort.
+	self hasLoop ifFalse: [ 
+		aStream nextPutAll: ' to '.
+		aStream nextPutAll:
+			(link
+				ifNil: [ self linkname ]
+				ifNotNil: [ link bytecodes first sourceLineShort. ]) ]
+
 ]
 
 { #category : #accessing }
@@ -444,11 +471,13 @@ RJITTrace >> start [
 
 { #category : #accessing }
 RJITTrace >> startLine [
-	| pt line chunk |
-	pt := [ self startPrototype ] on: RJITFlashbackDataMissing do: [ ^ '?' ].
-	chunk := [ pt sourceName ] on: RJITFlashbackDataMissing do: [ ^ '?' ].
-	line := [ pt programCounterLine: self start ] on: RJITFlashbackDataMissing do: [ ^ chunk ].
-	^ chunk , ':' , line asString.
+	^ self startPrototype sourcePC: self start.
+
+]
+
+{ #category : #accessing }
+RJITTrace >> startLineShort [
+	^ self startPrototype sourcePCShort: gctrace startpc.
 
 ]
 

--- a/frontend/Studio-RaptorJIT/String.extension.st
+++ b/frontend/Studio-RaptorJIT/String.extension.st
@@ -41,3 +41,9 @@ String >> asLinkTypeName [
 	^ (self withoutPrefix: 'LJ_TRLINK_') asLowercase asSymbol.
 
 ]
+
+{ #category : #'*Studio-RaptorJIT' }
+String >> luaModuleName [
+	^ self asPath basenameWithoutExtension: 'lua'.
+
+]


### PR DESCRIPTION
The UI can now read a new 'declname' debug attribute that provides the
declared name of a Lua function. This is used to revamp the UI to make
descriptions of code executed in traces simpler.

Some other improvements coming along for the ride...

The improvements only kick in when using a RaptorJIT version with
declname support.

Trace map and summary:

![screen shot 2018-05-09 at 13 21 02](https://user-images.githubusercontent.com/13791/39813579-4bdf5a7e-5391-11e8-903f-8ff8b90482a8.png)

Trace call stack contour:

![screen shot 2018-05-09 at 14 01 13](https://user-images.githubusercontent.com/13791/39813631-7f5b5ef2-5391-11e8-860e-e94dd749b55e.png)
