### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nixos/nix:latest
+RUN apk add --no-cache git bash
+ADD . studio/
+RUN nix-channel --update
+RUN studio/run cache
+EXPOSE 5901/tcp
+ENTRYPOINT ["studio/run"]
+CMD [""]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ $ git clone https://github.com/studio/studio # Get Studio
 $ studio/run vnc                             # Start GUI as VNC server
 ```
 
+And in a docker container:
+
+```shell
+$ git clone https://github.com/studio/studio      # Get Studio
+$ docker build -t studio studio                   # Build docker image from local git repo
+$ docker run -d -p 127.0.0.1:5901:5901 studio vnc # Run studio in the background in VNC mode, listening on localhost:5901
+$ vncviewer 127.0.0.1:5901                        # Connect to studio using TigerVNC
+```
+
 Optional extras:
 
 ```shell

--- a/bin/studio
+++ b/bin/studio
@@ -36,6 +36,7 @@ runstudio() {
   attr="$1"
   cmd="$2"
   export TMPDIR=$(mktemp -d)
+  chmod 755 $TMPDIR
   trap "rm -rf $TMPDIR" EXIT
   nix-shell $nixopts --run "STUDIO_PATH=$studio $cmd" -E - <<EOF
     with import $studio;
@@ -52,11 +53,14 @@ case "$1" in
     x11)
         runstudio studio.studio-x11 studio-x11
         ;;
+    cache)
+        runstudio "studio.studio-x11 studio.studio-vnc" "echo 'Cache retrieved...'"
+        ;;
     test)
         runstudio studio.studio-test studio-test
         ;;
     *)
-        error "Usage: studio <vnc|x11|test>"
+        error "Usage: studio <vnc|x11|cache|test>"
         ;;
 esac
 


### PR DESCRIPTION
Allows studio to be run in a docker container without having to install nix locally.

This supports execution in VNC mode. X11 mode should also work if the socket can be exposed inside the docker container in a way that `pharo` can find.