### PR TITLE
Support for inspecting multiple RaptorJIT processes

### DIFF
--- a/backend/snabb/default.nix
+++ b/backend/snabb/default.nix
@@ -10,10 +10,12 @@ with pkgs; with stdenv;
 
 rec {
   processDirectory = dir: runCommand "snabb-directory" { inherit dir; } ''
-    [ -f $dir/audit.log ] || (echo "error: ./audit.log not found" >&2; exit 1)
     cp --no-preserve=mode -r $dir $out
     cd $out
   '';
-  processTarball = url: processDirectory (fetchTarball url);
+  processTarball = url: runCommand "snabb-tarball" { inherit url; } ''
+    mkdir -p $out && cd $out
+    ${curl}/bin/curl "$url" | tar -x -J -k
+  '';
 
 }

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -94,21 +94,27 @@ RJITProcess >> gtInspectorTraceMapIn: composite [
 { #category : #'instance creation' }
 RJITProcess >> gtInspectorVMProfilesIn: composite [
 	<gtInspectorPresentationOrder: 5>
-	| w percent |
+	| w fmtPct percent samples |
 	w := 50. "width of numeric columns"
 	^ composite tabulator
 		title: 'VM Profile';
 		with: [ :t |
 			t row: #profiles; row: #locations; row: #traces.
 			t transmit to: #profiles; andShow: [ :a |
+				fmtPct := [ :pct |
+					(pct round: 1) asString , '%' ].
 				percent := [ :sel |
 					[ :obj |
-						[ ((obj perform: sel) round: 1) asString , '%' ] on: ZeroDivide do: [ '-' ] ] ].
+						[ fmtPct value: (obj perform: sel) ] on: ZeroDivide do: [ '-' ] ] ].
+				samples := [ :sel |
+					[ :obj |
+						(obj perform: sel) asString ,
+			  				' (' , (fmtPct value: (obj perform: sel) / self totalSamples * 100) , ')' ] ].
 				a fastTable
 					title: 'Profiler datasets (VMProfile)';
 					display: #vmprofiles;
 					column: 'Profile' evaluated: #name width: 100;
-					column: 'Samples' evaluated: #total width: 60
+					column: 'Samples' evaluated: (samples value: #total) width: 80
 						tags: nil sortedBy: [ :x :y | x total > y total ];
 					column: 'Mcode' evaluated: (percent value: #mcodePercent) width: w
 						tags: nil sortedBy: [ :x :y | x mcode > y mcode ];

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -109,7 +109,8 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 				samples := [ :sel |
 					[ :obj |
 						(obj perform: sel) asString ,
-			  				' (' , (fmtPct value: (obj perform: sel) / self totalSamples * 100) , ')' ] ].
+			  				([ ' (' , (fmtPct value: (obj perform: sel) / self totalSamples * 100) , ')' ]
+								on: ZeroDivide do: [ '' ]) ] ].
 				a fastTable
 					title: 'Profiler datasets (VMProfile)';
 					display: #vmprofiles;

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -148,6 +148,11 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 
 ]
 
+{ #category : #accesing }
+RJITProcess >> path [
+	^ path
+]
+
 { #category : #accessing }
 RJITProcess >> totalSamples [
 	vmprofiles isEmpty ifTrue: [ ^0 ].

--- a/frontend/Studio-RaptorJIT/RJITProcesses.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcesses.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #RJITProcesses,
+	#superclass : #Object,
+	#instVars : [
+		'processes',
+		'path'
+	],
+	#category : #'Studio-RaptorJIT'
+}
+
+{ #category : #'instance creation' }
+RJITProcesses >> fromPath: aPath [
+	path := aPath.
+	processes := OrderedCollection new.
+	[ processes add: (RJITProcess new fromPath: aPath) ]
+		ifError: [ "Root is not a RJITProcess" ].
+	aPath children do:
+		[ :child |
+			[ processes add: (RJITProcess new fromPath: child) ]
+				ifError: [  "Child directory is not a RJITProcess" ] ].
+	processes size = 1 ifTrue: [ ^ processes first ].
+]
+
+{ #category : #'as yet unclassified' }
+RJITProcesses >> gtInspectorFilesIn: composite [
+	<gtInspectorPresentationOrder: 10>
+	^ path gtInspectorItemsIn: composite.
+]
+
+{ #category : #'as yet unclassified' }
+RJITProcesses >> gtInspectorProcessesIn: composite [
+	<gtInspectorPresentationOrder: 5>
+	^ composite fastTable
+		title: 'RaptorJIT processes';
+		display: #processes;
+		column: 'Id' evaluated: [ :process | process path basename ] width: 100;
+		column: 'Profiles' evaluated: [ :process | process vmprofiles size ] width: 60;
+		column: 'Samples' evaluated: #totalSamples width: 60.
+		
+		
+]
+
+{ #category : #acccessing }
+RJITProcesses >> processes [
+	^ processes
+]

--- a/frontend/Studio-UI/StudioInspector.class.st
+++ b/frontend/Studio-UI/StudioInspector.class.st
@@ -31,7 +31,7 @@ StudioInspector >> go: code [
 				extent: self window extent * 0.9.
 			^ nil ].
 		job title: 'Studio frontend is analyzing data from the backend'.
-		^ RJITProcess new fromPath: product firstOutput.
+		^ RJITProcesses new fromPath: product firstOutput.
 	] asJob run.
 
 ]


### PR DESCRIPTION
![studio-rjit-processes](https://user-images.githubusercontent.com/4933566/49517821-571ef280-f89d-11e8-95a0-71fdd8a09508.png)

This adds an intermediary step/class that will scan the product path, if there is more than one RJITProcess it will instantiate a listing of processes.

Additionally, 99677de adds a percentage to the samples column in "Profiler datatsets".