### PR TITLE
Add batch-mode 'bin/studio decode <input> <output>'

### DIFF
--- a/backend/frontend/default.nix
+++ b/backend/frontend/default.nix
@@ -122,7 +122,7 @@ let
       cp ${studio-image}/pharo.changes pharo-$version.changes
       chmod +w pharo-$version.image
       chmod +w pharo-$version.changes
-      echo pharo-$version.image
+      realpath "pharo-$version.image"
     '';
   };
 
@@ -195,19 +195,46 @@ let
           ${pharo}/bin/pharo --nodisplay $image st --quit ${studio-test-script}
       '';
   };
+
+  studio-decode =
+    # Script to decode binary data into a more usable format.
+    let studio-decode-script = writeScript "studio-decode-script.st" ''
+        | env input output |
+        env := OSProcess thisOSProcess environment.
+        input := (env at: #STUDIO_DECODE_INPUT) asFileReference.
+        output := (env at: #STUDIO_DECODE_OUTPUT) asFileReference.
+        Transcript show: 'Studio decoding from ', input printString, ' to ', output printString; cr.
+        Studio decodeFrom: input to: output.
+        Transcript show: 'Finished.'; cr.
+      ''; in
+      writeTextFile {
+        name = "studio-decode-${studio-version}";
+        destination = "/bin/studio-decode";
+        executable = true;
+        text = ''
+          #!${stdenv.shell}
+          if [ $# != 2 ]; then
+            echo "usage: <input> <output>"
+            exit 1
+          fi
+          export STUDIO_DECODE_INPUT=$1
+          export STUDIO_DECODE_OUTPUT=$2
+          image=$(${studio-get-image}/bin/studio-get-image)
+          timeout 600 \
+            ${pharo}/bin/pharo --nodisplay $image st --quit ${studio-decode-script}
+        '';
+  };
 in
   
 {
   # main package collection for 'nix-env -i'
-  studio = { inherit studio-x11 studio-vnc studio-test tigervnc; };
+  studio = { inherit studio-x11 studio-vnc studio-test studio-decode tigervnc; };
   # individual packages
   studio-gui = studio-x11;           # deprecated
   studio-gui-vnc = studio-vnc;       # deprecated
   studio-base-image = base-image;
   studio-image = studio-image;
   inherit studio-inspector-screenshot;
-  inherit studio-x11 studio-vnc studio-test;
-
-
+  inherit studio-x11 studio-vnc studio-test studio-decode;
 }
 

--- a/bin/studio
+++ b/bin/studio
@@ -34,11 +34,11 @@ nixopts="--pure -j 10"
 
 runstudio() {
   attr="$1"
-  cmd="$2"
+  shift
   export TMPDIR=$(mktemp -d)
   chmod 755 $TMPDIR
   trap "rm -rf $TMPDIR" EXIT
-  nix-shell $nixopts --run "STUDIO_PATH=$studio $cmd" -E - <<EOF
+  nix-shell $nixopts --run "STUDIO_PATH=$studio $*" -E - <<EOF
     with import $studio;
     runCommandNoCC "studio" {
       nativeBuildInputs = [ nixUnstable xorg.xauth perl disasm $attr ];
@@ -58,6 +58,13 @@ case "$1" in
         ;;
     test)
         runstudio studio.studio-test studio-test
+        ;;
+    decode)
+        if [ $# != 3 ]; then
+            echo "Usage: studio decode <input> <output>" >&2
+            exit 1
+        fi
+        runstudio studio.studio-decode studio-decode "$2" "$3"
         ;;
     *)
         error "Usage: studio <vnc|x11|cache|test>"

--- a/frontend/Studio-DWARF/DWARF.class.st
+++ b/frontend/Studio-DWARF/DWARF.class.st
@@ -53,6 +53,7 @@ DWARF >> loadFromByteArray: array [
 	tmp := tmpdir / ('dwarf-',hash,'.dwo').
 	tmp writeStream binary nextPutAll: array; close.
 	self loadFromBinaryFileNamed: tmp pathString.
+
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-Nix/Nix.class.st
+++ b/frontend/Studio-Nix/Nix.class.st
@@ -43,7 +43,11 @@ Nix class >> command: commandLine [
 	stderr nextPutAll: err.
 	self showProgress: out.
 	self showProgress: err.
-	process succeeded ifFalse: [ NixError new messageText: stderr contents asByteArray utf8Decoded; signal ].
+	process succeeded ifFalse: [ 
+		| reason |
+		reason := stderr contents asByteArray utf8Decoded.
+		Transcript show: 'Nix error:'; cr; show: reason.
+		NixError new messageText: reason; signal ].
 	^ stdout contents.
 
 ]

--- a/frontend/Studio-Nix/Studio.class.st
+++ b/frontend/Studio-Nix/Studio.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #Studio,
+	#superclass : #Object,
+	#category : #'Studio-Nix'
+}
+
+{ #category : #'as yet unclassified' }
+Studio class >> decodeFrom: inputDirectory to: outputDirectory [
+	| preprocessed |
+	preprocessed := (Nix build: 'with import <studio>; raptorjit.inspect ', inputDirectory pathString)
+							first asFileReference.
+	RJITProcess new fromPath: preprocessed; textDumpInDirectory: outputDirectory.
+]

--- a/frontend/Studio-RaptorJIT/FileReference.extension.st
+++ b/frontend/Studio-RaptorJIT/FileReference.extension.st
@@ -3,10 +3,12 @@ Extension { #name : #FileReference }
 { #category : #'*studio-raptorjit' }
 FileReference >> dumpStudioFile: aFilename with: aBlock [ 
 	| file |
+	self ensureCreateDirectory.
 	file := self / aFilename.
+	file ensureDelete.
 	"Transcript show: 'Writing ', file pathString; cr."
 	[ file writeStreamDo: aBlock ] on: Error do: [ :error |
 		Transcript cr; show: 'Error on ', file pathString, ': ', error printString; cr.
-		(file withExtension: '.error') writeStreamDo: [ :s | s nextPutAll: error printString; cr ]
+		(file withExtension: 'error') writeStreamDo: [ :s | s nextPutAll: error printString; lf ]
 	].
 ]

--- a/frontend/Studio-RaptorJIT/FileReference.extension.st
+++ b/frontend/Studio-RaptorJIT/FileReference.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #FileReference }
+
+{ #category : #'*studio-raptorjit' }
+FileReference >> dumpStudioFile: aFilename with: aBlock [ 
+	| file |
+	file := self / aFilename.
+	"Transcript show: 'Writing ', file pathString; cr."
+	[ file writeStreamDo: aBlock ] on: Error do: [ :error |
+		Transcript cr; show: 'Error on ', file pathString, ': ', error printString; cr.
+		(file withExtension: '.error') writeStreamDo: [ :s | s nextPutAll: error printString; cr ]
+	].
+]

--- a/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
@@ -127,7 +127,7 @@ RJITAuditLog >> loadFromFileNamed: fileName [
 			self addRecord: mp next.
 			count := count + 1.
 			job progress: stream position / log size.
-			(stream position * 100.0 / log size) floor > percent ifTrue: [ 
+			((stream position * 100.0 / log size) floor / 5) floor > (percent / 5) floor ifTrue: [ 
 				percent := (stream position * 100.0 / log size) floor.
 				Transcript show: ('Reading audit.log progress: {1}% ({2} events)'
 										format: { percent. count. }); cr. ]

--- a/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
+++ b/frontend/Studio-RaptorJIT/RJITAuditLog.class.st
@@ -112,7 +112,7 @@ RJITAuditLog >> irOperandModes [
 
 { #category : #initialization }
 RJITAuditLog >> loadFromFileNamed: fileName [
-	| log mp stream count |
+	| log mp stream count percent |
 	[ :job |
 		job title: 'Reading audit.log into memory'.
 		events := OrderedCollection new.
@@ -121,11 +121,17 @@ RJITAuditLog >> loadFromFileNamed: fileName [
 		stream := ReadStream on: log.
 		mp := MpDecoder on: stream.
 		count := 1.
+		percent := 0.
 		[ [  mp atEnd ] whileFalse: [
 			job title: 'Reading audit.log record #', count asString.
 			self addRecord: mp next.
 			count := count + 1.
-			job progress: stream position / log size. ]
+			job progress: stream position / log size.
+			(stream position * 100.0 / log size) floor > percent ifTrue: [ 
+				percent := (stream position * 100.0 / log size) floor.
+				Transcript show: ('Reading audit.log progress: {1}% ({2} events)'
+										format: { percent. count. }); cr. ]
+			]
 		] on: Error do: [ :e | UIManager default inform: 'Finishing at msgpack error: ', e asString ].
 	] asJob run.
 	UIManager default inform: 'Loaded ', events size asString, ' RaptorJIT events (auditlog)'.

--- a/frontend/Studio-RaptorJIT/RJITDisassembler.class.st
+++ b/frontend/Studio-RaptorJIT/RJITDisassembler.class.st
@@ -15,6 +15,6 @@ RJITDisassembler class >> disassemble: byteArray address: address [
 	tmp := FileReference newTempFilePrefix: 'mcode' suffix: '.bin'.
 	tmp writeStream binary nextPutAll: byteArray asByteArray; close.
 	proc := PipeableOSProcess command: 'disasm ', tmp fullName, ' 0x', (address radix: 16).
-	^ proc output.
+	^ proc output copyReplaceAll: String tab with: '  '.
 
 ]

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -160,7 +160,8 @@ RJITIRInstruction >> constantValue [
 
 { #category : #initialization }
 RJITIRInstruction >> disassemble [
-	^ RJITDisassembler disassemble: mcode address: mcodeAddress.
+	^ trace disassembleFrom: mcodeAddress to: mcodeAddress + mcode size.
+
 ]
 
 { #category : #initialization }

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -156,8 +156,17 @@ RJITProcess >> textDumpInDirectory: aFileReferenceOrPath [
 	Transcript show: 'Dumping traces: '.
 	self traces do: [ :trace |
 		Transcript show: trace traceno asString, ' '; flush.
-		trace textDumpInDirectory: dir / trace traceno asString ].
+		trace textDumpInDirectory: dir / 'trace' / trace traceno asString ].
 	Transcript cr.
+	self vmprofiles
+		ifEmpty: [ 
+			Transcript show: '(No vmprofile data found)'; cr. ]
+		ifNotEmpty: [
+			Transcript show: 'Dumping vmprofiles: '.
+			self vmprofiles do: [ :prof |
+				Transcript show: prof name, ' '; flush.
+				prof textDumpInDirectory: dir / 'vmprofile'. ].
+			Transcript cr. ].
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -33,11 +33,11 @@ RJITProcess >> dwarf: aDWARF [
 { #category : #'instance creation' }
 RJITProcess >> fromPath: aPath [
 	| dwarfPath auditPath |
-	path := aPath.
+	path := aPath asFileReference.
 	dwarfPath := path / 'raptorjit-dwarf.json'.
 	auditPath := path / 'audit.log'.
 	[ auditPath isFile ] assertWithDescription:
-		'JIT audit log not found'.
+		'JIT audit log not found in ', path asString.
 	auditLog := RJITAuditLog new loadFromFileNamed: auditPath pathString.
 	auditLog process: self.
 	"Load VMProfile data with progress monitoring."
@@ -145,6 +145,15 @@ RJITProcess >> gtInspectorVMProfilesIn: composite [
 					allExpanded. ].
 			t transmit toOutsidePort: #selection; from: #traces port: #selection transformed: #trace.
 			].
+
+]
+
+{ #category : #'text dump' }
+RJITProcess >> textDumpInDirectory: aFileReferenceOrPath [
+	| dir |
+	dir := aFileReferenceOrPath asFileReference.
+	dir ensureDeleteAll; ensureCreateDirectory.
+	self traces do: [ :trace | trace textDumpInDirectory: dir / trace traceno asString ].
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -153,7 +153,11 @@ RJITProcess >> textDumpInDirectory: aFileReferenceOrPath [
 	| dir |
 	dir := aFileReferenceOrPath asFileReference.
 	dir ensureDeleteAll; ensureCreateDirectory.
-	self traces do: [ :trace | trace textDumpInDirectory: dir / trace traceno asString ].
+	Transcript show: 'Dumping traces: '.
+	self traces do: [ :trace |
+		Transcript show: trace traceno asString, ' '; flush.
+		trace textDumpInDirectory: dir / trace traceno asString ].
+	Transcript cr.
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -14,7 +14,10 @@ Class {
 		'linktype',
 		'start',
 		'jitState',
-		'nins'
+		'nins',
+		'mcode',
+		'mcodeAddress',
+		'mcodeInstructions'
 	],
 	#category : #'Studio-RaptorJIT'
 }
@@ -64,10 +67,12 @@ RJITTrace >> children [
 
 { #category : #'instance creation' }
 RJITTrace >> decodeIrMcodeMapping [
-	| szirmcode mcodeAddr mcodeOffset flashback nbytes index |
+	| szirmcode mcodeAddr mcodeOffset flashback nbytes index szmcode |
 	flashback := gctrace flashback.
 	szirmcode := gctrace szirmcode asInteger.
+	szmcode := gctrace szmcode asInteger.
 	mcodeAddr := gctrace mcode asInteger.
+	self mcode: (flashback bytesAt: mcodeAddr size: szmcode) address: mcodeAddr.
 	"First value is size of trace head (before first instruction)"
 	mcodeOffset := (flashback decodeTypeNamed: #uint16_t at: szirmcode) value.
 	index := 2.
@@ -79,6 +84,15 @@ RJITTrace >> decodeIrMcodeMapping [
 		index := index + 2. "next uint16_t"
 		mcodeOffset := mcodeOffset + nbytes.
 	].
+
+]
+
+{ #category : #disassemble }
+RJITTrace >> disassembleFrom: startAddr to: endAddr [ 
+	| lines |
+	lines := self mcodeInstructions select: [ :i | i key >= startAddr and: i key < endAddr ]
+										thenCollect: #value.
+	^ String cr join: lines.
 
 ]
 
@@ -251,7 +265,7 @@ RJITTrace >> irConstants [
 
 { #category : #'text dump' }
 RJITTrace >> irDump [
-	^ 'Trace ' , traceno asString, ' IR', String cr, self irListing.
+	^ self printString, String cr, self irListing.
 
 ]
 
@@ -384,30 +398,40 @@ RJITTrace >> loopInstructions [
 	^ self irInstructions copyAfter: self loop.
 ]
 
+{ #category : #'instance creation' }
+RJITTrace >> mcode: anArray address: anAddress [
+	mcode := anArray.
+	mcodeAddress := anAddress.
+
+]
+
 { #category : #'text dump' }
 RJITTrace >> mcodeDump [
-	^ 'Trace ' , traceno asString, ' mcode', String cr, self mcodeListing.
+	^ self printString, String cr, self mcodeListing.
+
+]
+
+{ #category : #'instance creation' }
+RJITTrace >> mcodeInstructions [
+	"Answer an ordered collection of address->disasssembly associations.
+	The result has one entry per machine instruction, with the address giving the
+	address of the instruction and the disassembly being a line of text from
+	the disassembler."
+	mcodeInstructions ifNil: [
+		| disasm |
+		disasm := RJITDisassembler disassemble: mcode address: mcodeAddress.
+		mcodeInstructions := disasm lines collect: [ :line |
+			(Integer readFrom: line base: 16) -> line. ] ].
+	^ mcodeInstructions
 
 ]
 
 { #category : #'as yet unclassified' }
 RJITTrace >> mcodeListing [
-	| disasm batches processes |
-	"Disassemble each IR instruction with a separate subprocess (objdump).
-	Do this in parallel to mask the latency of spawning subprocesses.
-	Work in fixed-size batches to avoid spawning too many subprocesses at once."
-	disasm := Dictionary new.
-	batches := self irInstructionsNoNop groupedBy: [ :i | i index // 100 ].
-	batches do: [ :batch |
-		processes := batch collect: [ :i |
-			[ disasm at: i put: i disassemble ] fork ].
-		[ processes allSatisfy: #isTerminated ] whileFalse: [ 
-			(Delay forMilliseconds: 10) wait ]
-	].
 	^ String streamContents: [ :s |
 		self irInstructionsNoNop do: [ :i |
 			| mcode firstmcode |
-			mcode := (disasm at: i) lines.
+			mcode := i disassemble lines.
 			firstmcode := mcode ifEmpty: [ '' ] ifNotEmpty: [ mcode first ].
 			s
 				nextPutAll: (firstmcode padRightTo: 54);
@@ -435,7 +459,7 @@ RJITTrace >> numberOfIrInstructions [
 
 { #category : #accessing }
 RJITTrace >> ownFunctionContour [
-	^ 'Trace ', self traceno asString, String cr, self functionContour.
+	^ self printString, String cr, self functionContour.
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -73,7 +73,6 @@ RJITTrace >> decodeIrMcodeMapping [
 	index := 2.
 	self irInstructions do: [ :ins |
 		nbytes := (flashback decodeTypeNamed: #uint16_t at: szirmcode + index) value.
-		Transcript show: 'nbytes: ', nbytes asString; cr.
 		ins mcode: (flashback bytesAt: mcodeAddr + mcodeOffset size: nbytes).
 		ins szmcode: nbytes.
 		ins mcodeAddress: mcodeAddr + mcodeOffset.
@@ -250,6 +249,12 @@ RJITTrace >> irConstants [
 	^ irConstants
 ]
 
+{ #category : #'text dump' }
+RJITTrace >> irDump [
+	^ 'Trace ' , traceno asString, ' IR', String cr, self irListing.
+
+]
+
 { #category : #initializing }
 RJITTrace >> irInstructions [
 	irInstructions isBlock ifTrue: [ 
@@ -379,6 +384,45 @@ RJITTrace >> loopInstructions [
 	^ self irInstructions copyAfter: self loop.
 ]
 
+{ #category : #'text dump' }
+RJITTrace >> mcodeDump [
+	^ 'Trace ' , traceno asString, ' mcode', String cr, self mcodeListing.
+
+]
+
+{ #category : #'as yet unclassified' }
+RJITTrace >> mcodeListing [
+	| disasm batches processes |
+	"Disassemble each IR instruction with a separate subprocess (objdump).
+	Do this in parallel to mask the latency of spawning subprocesses.
+	Work in fixed-size batches to avoid spawning too many subprocesses at once."
+	disasm := Dictionary new.
+	batches := self irInstructionsNoNop groupedBy: [ :i | i index // 100 ].
+	batches do: [ :batch |
+		processes := batch collect: [ :i |
+			[ disasm at: i put: i disassemble ] fork ].
+		[ processes allSatisfy: #isTerminated ] whileFalse: [ 
+			(Delay forMilliseconds: 10) wait ]
+	].
+	^ String streamContents: [ :s |
+		self irInstructionsNoNop do: [ :i |
+			| mcode firstmcode |
+			mcode := (disasm at: i) lines.
+			firstmcode := mcode ifEmpty: [ '' ] ifNotEmpty: [ mcode first ].
+			s
+				nextPutAll: (firstmcode padRightTo: 54);
+				nextPutAll: ' | ';
+				nextPutAll: i irString;
+				cr.
+			mcode allButFirstDo: [ :nextmcode |
+				s
+					nextPutAll: (nextmcode padRightTo: 54);
+					nextPutAll: ' |';
+					cr. ]
+			]
+		].
+]
+
 { #category : #initializing }
 RJITTrace >> numberOfHeadIrInstructions [
 	^ self headInstructions size.
@@ -485,6 +529,20 @@ RJITTrace >> startLineShort [
 RJITTrace >> startPrototype [
 	^ gctrace flashback decodeGCprotoAt: gctrace startpt.
 
+]
+
+{ #category : #'text dump' }
+RJITTrace >> textDumpInDirectory: dir [ 
+	dir ensureCreateDirectory.
+	dir dumpStudioFile: 'name.txt' with: [ :s |
+		s text. s nextPutAll: self asString withUnixLineEndings ].
+	dir dumpStudioFile: 'ir.txt' with: [ :s | 
+		s text. s nextPutAll: self irDump withUnixLineEndings ].
+	dir dumpStudioFile: 'mcode.txt' with: [ :s | 
+		s text. s nextPutAll: self mcodeDump withUnixLineEndings ].
+	dir dumpStudioFile: 'contour.txt' with: [ :s | 
+		s text. s nextPutAll: self ownFunctionContour withUnixLineEndings ]
+	
 ]
 
 { #category : #accessing }

--- a/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
@@ -113,6 +113,27 @@ RJITVMProfile >> process: aRaptorJITProcess [
 	process := aRaptorJITProcess.
 ]
 
+{ #category : #'text dump' }
+RJITVMProfile >> textDumpInDirectory: dir [
+	| tracelist sep |
+	sep := ' | '.
+	tracelist := self traces select: [ :tr | tr all > 0 ].
+	tracelist sort: [ :a :b | a all > b all ].
+	dir asFileReference dumpStudioFile: (self name, '.txt') with: [ :s |
+		#(Samples MCode VM GC) do: [ :col |
+			s nextPutAll: (col padRightTo: 8), sep. ].
+		s nextPutAll: 'Trace'.
+		s lf.
+		tracelist do: [ :tr |
+			s nextPutAll: (tr all asString padLeftTo: 8), sep.
+			{  tr mcodePercent. tr vmPercent. tr gcPercent } do: [ :pct |
+				s nextPutAll: ((pct printShowingDecimalPlaces: 1), '%' padLeftTo: 6), '  ', sep ].
+			s nextPutAll: (process traces detect: [ :trace | trace traceno = tr id ]) printString.
+			s lf.
+		 ]
+	].
+]
+
 { #category : #'accessing-data' }
 RJITVMProfile >> total [
 	^ (traces collect: #all) sum.
@@ -122,6 +143,11 @@ RJITVMProfile >> total [
 { #category : #'accessing-data' }
 RJITVMProfile >> trace: tr [
 	^ traces detect: [ :profile | profile id = tr traceno ].
+]
+
+{ #category : #'accessing-data' }
+RJITVMProfile >> traces [
+	^ traces
 ]
 
 { #category : #'accessing-data' }

--- a/overlays.nix
+++ b/overlays.nix
@@ -5,7 +5,7 @@
   (self: super:
     with super.callPackage ./backend/frontend {};
     {
-      inherit studio studio-gui studio-gui-vnc studio-base-image studio-image studio-inspector-screenshot;
+      inherit studio studio-gui studio-gui-vnc studio-base-image studio-image studio-inspector-screenshot studio-decode;
       raptorjit = super.callPackage ./backend/raptorjit {};
       snabb = super.callPackage ./backend/snabb {};
       snabbr = super.callPackage ./backend/snabbr {};


### PR DESCRIPTION
This branch adds initial batch-mode operation for Studio. You can write on the command line

    bin/studio decode raptorjit/audit.log textdump

and this will read your RaptorJIT log (or Snabb directory) and write out all the JIT traces in ascii text.

Currently hard-coded for RaptorJIT/Snabb and only handling traces (not profiles etc.) Have to think about the best way to extend in going forward.

Currently also a bit slow and in need of optimization.