### PR TITLE
.travis.yml: Install Cachix in Domen-recommended way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ services:
 - docker
 
 script:
-- nix-env -if https://github.com/cachix/cachix/tarball/master --extra-substituters https://cachix.cachix.org --trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-  cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM='
-- if test -n "$authtoken"; then cachix authtoken $authtoken; fi
+- nix-env -iA cachix -f https://cachix.org/api/v1/install
 - cachix use studio
 - nix-build -j2 -A studio-env . | cachix push studio
 - docker build -t studioproject/$TRAVIS_BRANCH .


### PR DESCRIPTION
Previously Cachix would sometimes be built from source instead of downloaded as binary.