### PR TITLE
Frontend: Add "VMProfiles" tab to RJITProcess

### DIFF
--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -175,7 +175,7 @@ RJITProcess >> gtVMProfilesFor: aView [
 	<gtView>
 	| profiles |
 	profiles := RJITProfileList withAll: (self vmprofiles collect: #profile).
-	^ (profiles subjectViewTitled: 'VMProfiles' translated subjectName: 'VMProfile' translated onView: aView) priority: 10
+	^ (profiles subjectViewTitled: 'VMProfiles' translated subjectName: 'VMProfile' translated onView: aView) priority: 20
 ]
 
 { #category : #accessing }
@@ -248,6 +248,12 @@ RJITProcess >> totalSamples [
 RJITProcess >> totalSamplesFor: trace [
 	vmprofiles ifEmpty: [ ^0 ]. 
 	^ vmprofiles sum: [ :p | (p trace: trace) all]
+]
+
+{ #category : #accessing }
+RJITProcess >> trace: traceno [
+	^ self traces at: traceno
+
 ]
 
 { #category : #visualization }

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -211,7 +211,9 @@ RJITProcess >> test [
 	^{
 		self gtHotTracesFor: GtPhlowView empty.
 		self gtProfileFor: GtPhlowView empty.
+		self gtVMProfilesFor: GtPhlowView empty.
 		self traces collect: #test.
+		self vmprofiles collect: #test.
 	}.
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITProcess.class.st
+++ b/frontend/Studio-RaptorJIT/RJITProcess.class.st
@@ -170,6 +170,14 @@ RJITProcess >> gtProfileFor: aView [
 
 ]
 
+{ #category : #'instance creation' }
+RJITProcess >> gtVMProfilesFor: aView [
+	<gtView>
+	| profiles |
+	profiles := RJITProfileList withAll: (self vmprofiles collect: #profile).
+	^ (profiles subjectViewTitled: 'VMProfiles' translated subjectName: 'VMProfile' translated onView: aView) priority: 10
+]
+
 { #category : #accessing }
 RJITProcess >> label: arg1 [
 	self shouldBeImplemented

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -151,6 +151,7 @@ RJITTrace >> gtContourFor: aView [
 	^aView textEditor
 		title: 'Contour';
 		priority: 5;
+		look: BrGlamorousCodeEditorLook new;
 		text: [ (self printString, String cr, self functionContour) asRopedText ].
 
 ]
@@ -252,6 +253,17 @@ RJITTrace >> gtJITFor: aView [
 		title: 'JIT Events';
 		priority: 25;
 		items: [ self jitEvents ].
+
+]
+
+{ #category : #accessing }
+RJITTrace >> gtMCodeFor: aView [
+	<gtView>
+	^aView textEditor
+		title: 'MCode';
+		priority: 10;
+		look: BrGlamorousCodeEditorLook new;
+		text: [ (self mcodeDump) asRopedText ].
 
 ]
 

--- a/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
@@ -31,9 +31,9 @@ Class {
 { #category : #'instance creation' }
 RJITVMProfile class >> loadFromFileNamed: filename name: aName process: aProcess [
 	^self new
-		loadFromFileNamed: filename;
-		name: aName;
 		process: aProcess;
+		name: aName;
+		loadFromFileNamed: filename;
 		yourself.
 ]
 
@@ -49,6 +49,14 @@ RJITVMProfile >> gcPercent [
 ]
 
 { #category : #initialization }
+RJITVMProfile >> gtHotTracesFor: aView [
+	<gtView>
+	| profiles |
+	profiles := self traceProfiles sort: [ :a :b | a all > b all ].
+	^ (profiles subjectViewTitled: 'Hot traces' translated subjectName: 'Trace' translated onView: aView).
+]
+
+{ #category : #initialization }
 RJITVMProfile >> gtInspectorHotTracesIn: composite [
 	"<gtInspectorPresentationOrder: 5>"
 	process ifNil: [ ^nil ].
@@ -61,18 +69,17 @@ RJITVMProfile >> gtInspectorHotTracesIn: composite [
 RJITVMProfile >> loadFromFileNamed: aFilename [
 	| data index |
 	data := (File named: aFilename) readStream upToEnd.
-	[ (data unsignedLongAt: 1) = 16r1d50f007 ] assert.
-	[ (data unsignedShortAt: 5) = 4 ] assert.
+	[ (data unsignedLongAt: 1) = 16r1d50f007 ]  assert.
+	[ (data unsignedShortAt: 5) = 4 ]  assert.
 	index := 8.
-	traceProfiles := (0 to: 4096) collect: [ :tr |
-		| profile subject |
+	traceProfiles := RJITProfileList withAll: ((0 to: process traces size) collect: [ :tr |
+		| prof subject |
 		subject := { #trace -> tr. #vmprofile -> self. } asDictionary.
-		profile := RJITProfile new subject: subject; yourself.
+		prof := RJITProfile new subject: (self lookupTrace: tr); yourself.
 		#(interp: c: igc: exit: record: opt: asm: head: loop: jgc: ffi:) do: [ :selector |
-			profile perform: selector with: (data unsignedLongLongAt: index+1).
+			prof perform: selector with: (data unsignedLongLongAt: index+1).
 			index := index + 8. ].
-		profile. ].
-
+		prof. ])
 ]
 
 { #category : #accessing }
@@ -83,6 +90,14 @@ RJITVMProfile >> locations [
 	groups keysAndValuesDo: [ :loc :trs |
 		locations add: (RJITRootTraceSet new location: loc value; traces: trs; profile: self). ].
 	^ locations.
+]
+
+{ #category : #initialization }
+RJITVMProfile >> lookupTrace: traceno [
+	^ traceno = 0
+		ifTrue: [ '(Unknown)' ]
+		ifFalse: [ [ process trace: traceno ]
+						on: SubscriptOutOfBounds do: [ '(No trace ', traceno printString, ')'  ] ]
 ]
 
 { #category : #'accessing-data' }

--- a/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
@@ -143,6 +143,11 @@ RJITVMProfile >> profile [
 
 ]
 
+{ #category : #testing }
+RJITVMProfile >> test [ 
+	^ self gtHotTracesFor: GtPhlowView empty.
+]
+
 { #category : #'text dump' }
 RJITVMProfile >> textDumpInDirectory: dir [
 	| tracelist sep |

--- a/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
@@ -106,6 +106,11 @@ RJITVMProfile >> name: aName [
 	name := aName.
 ]
 
+{ #category : #printing }
+RJITVMProfile >> printOn: aStream [
+	aStream nextPutAll: name
+]
+
 { #category : #initialization }
 RJITVMProfile >> process [
 	^process


### PR DESCRIPTION
Support browsing individual VMProfile datasets.

- [x] List VMProfiles for a process.
- [x] List hot traces for each VMProfile.
- [x] Add test coverage for VMProfile views.