### PR TITLE
[wip] Reintroduce IR visualizations

### DIFF
--- a/backend/frontend/default.nix
+++ b/backend/frontend/default.nix
@@ -25,9 +25,9 @@ let
   # Built on Inria CI (Jenkins) with Metacello to install Studio.
   base-image = fetchImageZip rec {
     name = "studio-base-image-${version}.zip";
-    version = "0.5.126";
+    version = "0.6.46";
     url = "https://github.com/studio/base-images/raw/master/Studio-Base-GToolkit-v${version}.zip";
-    sha256 = "0g60x8y7g3qva2cidi1rv0g7s70yc6ds6j5p4ljknqg9ck2hbg7p";
+    sha256 = "120g1ahh6g7v1fkng5dqs3zfiiaq66f68yqn36p2fzp082xgc877";
   };
 
   # Script to update and customize the image for Studio.

--- a/frontend/Studio-RaptorJIT/RJITBlIRFragment.class.st
+++ b/frontend/Studio-RaptorJIT/RJITBlIRFragment.class.st
@@ -1,0 +1,74 @@
+Class {
+	#name : #RJITBlIRFragment,
+	#superclass : #BlElement,
+	#instVars : [
+		'irInstructions',
+		'irElems',
+		'testNodes',
+		'testEdges'
+	],
+	#category : #'Studio-RaptorJIT'
+}
+
+{ #category : #'as yet unclassified' }
+RJITBlIRFragment class >> forIrInstructions: irInstructions [
+	^ self new irInstructions: irInstructions.
+]
+
+{ #category : #'as yet unclassified' }
+RJITBlIRFragment class >> forTrace: aTrace [
+	^ self forIrInstructions: aTrace irInstructions.
+]
+
+{ #category : #accessing }
+RJITBlIRFragment >> irInstructions: irInstructionList [
+	irInstructions := irInstructionList.
+	irElems := (irInstructions collect: [ :ins | ins -> ins asElement ]) asDictionary.
+	self layoutInstructions.
+]
+
+{ #category : #accessing }
+RJITBlIRFragment >> layoutInstructions [
+	"Add layout constraints for edges between instructions."
+	testNodes := irElems keys collect: [ :ins | ins index asString  ].
+	testEdges := irElems keys flatCollect: [ :ins |
+		| x |
+		x := OrderedCollection new.
+		ins op1ins ifNotNil: [ :op | x add: (op index asString) -> ins index asString ].
+		ins op2ins ifNotNil: [ :op | x add: (op index asString) -> ins index asString ].
+		x
+		 ].
+	irElems keysAndValuesDo: [ :ins :elem |
+		self addChild: elem.
+		elem graph beNode.
+		{ ins op1ins. ins op2ins. } do: [ :op |
+			op ifNotNil: [ 
+				(irElems includesKey: op) ifTrue: [ 
+					| opElem line edge |
+					opElem := irElems at: op.
+					line := BlLineElement new.
+					line constraintsDo: [ :c | c ignoreByLayout ].
+					line
+						zIndex: -1;
+						border: (BlBorder paint: Color black);
+						fromAnchor: (BlElementBottomCenterAnchor element: opElem opcode);
+						toAnchor: (op = ins op1ins ifTrue: [ BlElementTopLeftAnchor element: elem ] ifFalse: [ BlElementTopRightAnchor element: elem ]).
+					self addChild: line.
+					edge := GtGraphEdge new from: (irElems at: op) to: elem.
+					elem constraintsDo: [ :c | c graph addConnectedEdge: edge ].
+					(irElems at: op) constraintsDo: [ :c | c graph addConnectedEdge: edge ].
+				 ]
+				] 
+			]
+		 ].
+	self
+"		layout: GtGraphTreeLayout new."
+		layout: (GtGradNorthHierarchicalTreeLayout new levelDistance: 5).
+"		layout: (GtGradNorthHierarchicalLayout new interRanksSpacing: 20)."
+
+"
+constraintsDo: [ :c |
+			c horizontal fitContent.
+			c vertical fitContent. ].
+"
+]

--- a/frontend/Studio-RaptorJIT/RJITBlIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITBlIRInstruction.class.st
@@ -1,0 +1,107 @@
+Class {
+	#name : #RJITBlIRInstruction,
+	#superclass : #BlElement,
+	#instVars : [
+		'irIns',
+		'opcode'
+	],
+	#category : #'Studio-RaptorJIT'
+}
+
+{ #category : #'instance creation' }
+RJITBlIRInstruction class >> for: anIrIns [
+	^ self new irIns: anIrIns
+]
+
+{ #category : #initialization }
+RJITBlIRInstruction >> addChildFromInlineStringIfNotNil: aString [
+	aString ifNotNil: [ self addChild: (self blInlineText: aString) ].
+
+]
+
+{ #category : #initialization }
+RJITBlIRInstruction >> blBorder [
+	| builder |
+	builder := BlBorder builder paint: Color black.
+	irIns isSpilledOntoStack ifTrue: [ builder width: 2 ].
+	irIns szmcode = 0 ifTrue: [ builder dashed ].
+	^ builder build.
+
+]
+
+{ #category : #initialization }
+RJITBlIRInstruction >> blInlineText: aString [
+	| container text |
+
+	container := BlElement new
+		layout: BlFrameLayout new;
+		border: (BlBorder paint: Color gray);
+		padding: (BlInsets left: 5 right: 5);
+		constraintsDo: [ :c |
+			c vertical matchParent.
+			c horizontal matchParent. ].
+
+	text := BlTextElement new 
+			text: aString asRopedText glamorousCodeFont;
+			constraintsDo: [ :c |
+				c frame vertical alignCenter.
+				c frame horizontal alignCenter. ].
+			
+	container addChild: text.
+
+	^ container
+]
+
+{ #category : #initialization }
+RJITBlIRInstruction >> blOpcode [
+	| container shape |
+
+	container := BlElement new
+		layout: BlFrameLayout new;
+		border: self blBorder;
+		background: irIns opcodeColor; 
+		width: 50;
+		height: 20.
+
+	shape := BlTextElement new
+					text: irIns opcode asRopedText glamorousCodeFont;
+					constraintsDo: [ :c |
+						c frame vertical alignCenter.
+						c frame horizontal alignCenter. ].
+
+	"no mcode border dashed"
+	"isSpilledOntoStack border bold"
+
+	container addChild: shape.
+	
+	^ container
+]
+
+{ #category : #initialization }
+RJITBlIRInstruction >> initializeChildren [
+	self addChildFromInlineStringIfNotNil: irIns op1InlineString.
+	opcode := self blOpcode.
+	self addChild: opcode.
+	self addChildFromInlineStringIfNotNil: irIns op2InlineString.
+	self constraintsDo: [ :c | c horizontal fitContent. c vertical fitContent. ].
+	self layout: (BlLinearLayout horizontal).
+
+]
+
+{ #category : #intialization }
+RJITBlIRInstruction >> initializeEvents [
+	self when: BlClickEvent do: [ :e |
+		self phlow spawnObject: irIns ]
+]
+
+{ #category : #initialization }
+RJITBlIRInstruction >> irIns: anIrIns [
+	irIns := anIrIns.
+	self initializeChildren.
+	self initializeEvents.
+]
+
+{ #category : #accessing }
+RJITBlIRInstruction >> opcode [
+	^ opcode
+]

--- a/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
+++ b/frontend/Studio-RaptorJIT/RJITIRInstruction.class.st
@@ -131,7 +131,7 @@ RJITIRInstruction class >> opcodeSummaries [
 
 { #category : #roassal }
 RJITIRInstruction >> asElement [
-	^ self shape elementOn: self.
+	^ RJITBlIRInstruction for: self
 ]
 
 { #category : #initialization }
@@ -141,6 +141,76 @@ RJITIRInstruction >> attributes [
 		'Type' -> type.
 		'Opcode' -> opcode.
 		}
+]
+
+{ #category : #roassal }
+RJITIRInstruction >> baseBlShape [
+	| container shape |
+
+	container := BlElement new
+		layout: BlFrameLayout new;
+		border: self blBorder;
+		background: self opcodeColor; 
+		width: 50;
+		height: 20.
+
+	shape := BlTextElement new
+					text: self opcode asRopedText glamorousCodeFont;
+					constraintsDo: [ :c |
+						c frame vertical alignCenter.
+						c frame horizontal alignCenter. ].
+
+	"no mcode border dashed"
+	"isSpilledOntoStack border bold"
+
+	container addChild: shape.
+	
+	^ container
+]
+
+{ #category : #roassal }
+RJITIRInstruction >> blBorder [
+	| builder |
+	builder := BlBorder builder paint: Color black.
+	self isSpilledOntoStack ifTrue: [ builder width: 2 ].
+	szmcode = 0 ifTrue: [ builder dashed ].
+	^ builder build.
+
+]
+
+{ #category : #bloc }
+RJITIRInstruction >> blInlineText: aString [
+	| container text |
+
+	container := BlElement new
+		layout: BlFrameLayout new;
+		border: (BlBorder paint: Color gray);
+		padding: (BlInsets left: 5 right: 5);
+		constraintsDo: [ :c |
+			c vertical matchParent.
+			c horizontal matchParent. ].
+
+	text := BlTextElement new 
+			text: aString asRopedText glamorousCodeFont;
+			constraintsDo: [ :c |
+				c frame vertical alignCenter.
+				c frame horizontal alignCenter. ].
+			
+	container addChild: text.
+
+	^ container
+]
+
+{ #category : #bloc }
+RJITIRInstruction >> blShape [
+	| el |
+	el := BlElement new.
+	self op1InlineString ifNotNil: [ :s | el addChild: (self blInlineText: s) ].
+	el addChild: self baseBlShape as: #opcode.
+	self op2InlineString ifNotNil: [ :s | el addChild: (self blInlineText: s) ].
+	el constraintsDo: [ :c | c horizontal fitContent. c vertical fitContent. ].
+	el layout: (BlLinearLayout horizontal).	
+	^ el
 ]
 
 { #category : #accessing }
@@ -156,7 +226,7 @@ RJITIRInstruction >> disassemble [
 
 { #category : #initialization }
 RJITIRInstruction >> gtInputsListingIn: aView [
-	<gtView>
+	"<gtView>"
 	^ (self transitiveInputs irColumnedListViewIn: aView title: 'Inputs' translated) priority: 11.
 
 ]
@@ -173,15 +243,25 @@ RJITIRInstruction >> gtMCodeFor: aView [
 ]
 
 { #category : #initialization }
+RJITIRInstruction >> gtRelatedGraphIn: aView [
+	<gtView>
+	^ aView explicit
+		title: 'Related Graph';
+		priority: 15;
+		stencil: [ RJITBlIRFragment forIrInstructions: self transitiveRelations ].
+
+]
+
+{ #category : #initialization }
 RJITIRInstruction >> gtRelatedListingIn: aView [
 	<gtView>
-	^ (self transitiveRelations irColumnedListViewIn: aView title: 'Related' translated) priority: 10.
+	^ (self transitiveRelations irColumnedListViewIn: aView title: 'Related List' translated) priority: 10.
 
 ]
 
 { #category : #initialization }
 RJITIRInstruction >> gtUsesListingIn: aView [
-	<gtView>
+	"<gtView>"
 	^ (self transitiveUses irColumnedListViewIn: aView title: 'Uses' translated) priority: 12.
 
 ]
@@ -595,6 +675,11 @@ RJITIRInstruction >> setPhiOperand [
 { #category : #initialization }
 RJITIRInstruction >> stackSlot [
 	^ stackSlot
+]
+
+{ #category : #printing }
+RJITIRInstruction >> szmcode [
+	^ szmcode
 ]
 
 { #category : #accessing }

--- a/frontend/Studio-RaptorJIT/RJITTrace.class.st
+++ b/frontend/Studio-RaptorJIT/RJITTrace.class.st
@@ -142,7 +142,7 @@ RJITTrace >> gtContourFor: aView [
 	<gtView>
 	^aView textEditor
 		title: 'Contour';
-		priority: 5;
+		priority: 1;
 		look: BrGlamorousCodeEditorLook new;
 		text: [ (self printString, String cr, self functionContour) asRopedText ].
 
@@ -173,9 +173,19 @@ RJITTrace >> gtFamilyFor: aView [
 ]
 
 { #category : #'gt-inspector-extension' }
+RJITTrace >> gtIRGraphFor: aView [
+	<gtView>
+	^ aView explicit
+		title: 'IR Graph';
+		priority: 17;
+		stencil: [ self irGraphView ].
+
+]
+
+{ #category : #'gt-inspector-extension' }
 RJITTrace >> gtIRListingFor: aView [
 	<gtView>
-	^ self irInstructionsNoNop irColumnedListViewIn: aView title: 'IR List'.
+	^ (self irInstructions irColumnedListViewIn: aView title: 'IR List') priority: 15.
 
 ]
 
@@ -212,7 +222,7 @@ RJITTrace >> gtInspectorGCTraceIn: composite [
 { #category : #deprecated }
 RJITTrace >> gtInspectorIRListingIn: composite [
 	"<gtInspectorPresentationOrder: 3>"
-	self irInstructionsNoNop irListViewIn: composite title: 'IR List'.
+	self irInstructions irListViewIn: composite title: 'IR List'.
 
 ]
 
@@ -277,7 +287,7 @@ RJITTrace >> gtMCodeFor: aView [
 	<gtView>
 	^aView textEditor
 		title: 'MCode';
-		priority: 10;
+		priority: 20;
 		look: BrGlamorousCodeEditorLook new;
 		text: [ (self mcodeDump) asRopedText ].
 
@@ -286,8 +296,7 @@ RJITTrace >> gtMCodeFor: aView [
 { #category : #'gt-inspector-extension' }
 RJITTrace >> gtProfileFor: aView [
 	<gtView>
-	^ self profile gtProfileFor: aView
-
+	^ (self profile gtProfileFor: aView) priority: 5
 ]
 
 { #category : #initializing }
@@ -344,12 +353,19 @@ RJITTrace >> irDump [
 
 ]
 
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> irGraphView [
+	^ RJITBlIRFragment forTrace: self
+
+]
+
 { #category : #initializing }
 RJITTrace >> irInstructions [
 	irInstructions isBlock ifTrue: [ 
 		irInstructions := irInstructions value.
 		irInstructions do: [ :ins | ins link: self. ].
 		self decodeIrMcodeMapping.
+		irInstructions := irInstructions reject: #isNop.
  		].
 	^ irInstructions.
 
@@ -363,13 +379,68 @@ RJITTrace >> irInstructionsNoNop [
 { #category : #'as yet unclassified' }
 RJITTrace >> irListing [
 	^ String streamContents: [ :s |
-		self irInstructionsNoNop do: [ :i | s nextPutAll: i irString; cr. ] ].
+		self irInstructions do: [ :i | s nextPutAll: i irString; cr. ] ].
 
 ]
 
 { #category : #'gt-inspector-extension' }
+RJITTrace >> irTreeBlView [
+	^ self irTreeBlViewOfInstructionGroups:
+		(self hasLoop
+			ifTrue: [ { self headInstructions. self loopInstructions. } ]
+			ifFalse: [ { self irInstructions } ])
+]
+
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> irTreeBlViewOfInstructionGroups: groups [
+	| view |
+	view := BlElement new
+				layout: BlFlowLayout vertical;
+				constraintsDo: [ :c |
+					c horizontal fitContent.
+					c vertical fitContent. ].
+	groups do: [ :group | 
+		view addChild: ((self irTreeFragment: group) root
+			constraintsDo: [ :c |
+				c horizontal fitContent.
+				c vertical fitContent ]) ].
+	^ view asScrollableElement
+
+]
+
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> irTreeBlViewOfInstructions: insns [
+	^ self irTreeBlViewOfInstructionGroups:
+		(self hasLoop
+			ifTrue: [ { self headInstructions. self loopInstructions. } ]
+			ifFalse: [ { self irInstructions } ])
+]
+
+{ #category : #'gt-inspector-extension' }
+RJITTrace >> irTreeFragment: insns [
+	"Answer a Bloc view of the instructions (head or loop but not mixed.)"
+	| view |
+	view := GtMondrian new.
+	view nodes
+		shape: [ :ins | ins blShape ];
+		with: insns.
+	"Edges included in layout."
+	view edges
+		fromCenterBottom;
+		toTopLeft;
+		connectFrom: #op1ins.
+	view edges
+		fromCenterBottom;
+		toTopRight;
+		connectFrom: #op2ins.
+	"Edges excluded from layout."
+	view layout custom: GtGradNorthHierarchicalTreeLayout new.
+	^ view
+]
+
+{ #category : #'gt-inspector-extension' }
 RJITTrace >> irTreeView [
-	^ self irTreeViewOfInstructions: self irInstructionsNoNop.
+	^ self irTreeViewOfInstructions: self irInstructions.
 ]
 
 { #category : #accessing }
@@ -455,16 +526,16 @@ RJITTrace >> mcodeInstructions [
 { #category : #'as yet unclassified' }
 RJITTrace >> mcodeListing [
 	^ String streamContents: [ :s |
-		self irInstructionsNoNop do: [ :i |
-			| mcode firstmcode |
-			mcode := i disassemble lines.
-			firstmcode := mcode ifEmpty: [ '' ] ifNotEmpty: [ mcode first ].
+		self irInstructions do: [ :i |
+			| mc firstmcode |
+			mc := i disassemble lines.
+			firstmcode := mc ifEmpty: [ '' ] ifNotEmpty: [ mc first ].
 			s
 				nextPutAll: (firstmcode padRightTo: 54);
 				nextPutAll: ' | ';
 				nextPutAll: i irString;
 				cr.
-			mcode allButFirstDo: [ :nextmcode |
+			mc allButFirstDo: [ :nextmcode |
 				s
 					nextPutAll: (nextmcode padRightTo: 54);
 					nextPutAll: ' |';


### PR DESCRIPTION
This branch is reintroducing the signature RaptorJIT IR visualizations that were the first feature of Studio but were temporarily lost in the port from "old GToolkit" with Roassal to "new GToolkit" with Bloc.

TODO:
- [ ] Scrolling on large visualizations.
- [ ] Zoom in/out on large visualizations.
- [ ] Show `--LOOP--` divider.
- [ ] Sort subgraphs with deepest part on the left ("nice to have.")

Screenshot:

![PharoScreenshot 8](https://user-images.githubusercontent.com/13791/57776902-ec61c500-7720-11e9-8c92-1ad6b4f0152a.png)

