### PR TITLE
Fixes for Alex Gall's test data

### DIFF
--- a/backend/frontend/default.nix
+++ b/backend/frontend/default.nix
@@ -117,8 +117,14 @@ let
     (Smalltalk saveAs: 'studio')
       ifTrue: [
         "Run in resumed image on startup."
-	GtInspector openOn:
-          (GtDocumenter forFile: Studio dir / 'doc' / 'Studio.pillar').
+         GtWorld openWithSpaces: { 
+            BlSpace new
+                title: 'Studio Overview';
+                addChild: (GtDocumenter forFile: Studio dir / 'doc' / 'Studio.pillar').
+            BlSpace new
+                title: 'Playground';
+                addChild: GtPlayground create
+        }
       ].
 
     Transcript show: 'Done.'; cr.

--- a/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
+++ b/frontend/Studio-RaptorJIT/RJITVMProfile.class.st
@@ -67,16 +67,19 @@ RJITVMProfile >> gtInspectorHotTracesIn: composite [
 
 { #category : #initialization }
 RJITVMProfile >> loadFromFileNamed: aFilename [
-	| data index |
+	| data index categories numberOfBuckets count |
 	data := (File named: aFilename) readStream upToEnd.
 	[ (data unsignedLongAt: 1) = 16r1d50f007 ]  assert.
 	[ (data unsignedShortAt: 5) = 4 ]  assert.
 	index := 8.
-	traceProfiles := RJITProfileList withAll: ((0 to: process traces size) collect: [ :tr |
+	categories := #(interp: c: igc: exit: record: opt: asm: head: loop: jgc: ffi:).
+	numberOfBuckets := (data size - index) / (categories size * 8).
+	count := process traces size min: numberOfBuckets.
+	traceProfiles := RJITProfileList withAll: ((1 to: count) collect: [ :tr |
 		| prof subject |
 		subject := { #trace -> tr. #vmprofile -> self. } asDictionary.
 		prof := RJITProfile new subject: (self lookupTrace: tr); yourself.
-		#(interp: c: igc: exit: record: opt: asm: head: loop: jgc: ffi:) do: [ :selector |
+		categories do: [ :selector |
 			prof perform: selector with: (data unsignedLongLongAt: index+1).
 			index := index + 8. ].
 		prof. ])


### PR DESCRIPTION
Fixes Studio to load @alexandergall's test data.

Still does not handle JIT flushes gracefully.

@alexandergall here's how it should look when the UI opens you into a blank "playground" and you enter a snippet to load your data:

![Selection_015](https://user-images.githubusercontent.com/13791/104571470-6a434580-5653-11eb-9e2f-bf89a86a4031.png)


(The `gt` and `Studio Overview` tabs are there too if you want to browse docs/examples.)